### PR TITLE
Add department colors to classes

### DIFF
--- a/src/components/Class.vue
+++ b/src/components/Class.vue
@@ -3,14 +3,14 @@
 <template>
   <v-flex md3>
     <v-card
-      :class="{classbox: true, satisfied: isSatisfied}"
+      :class="[{classbox: true, satisfied: isSatisfied}, courseColor]"
       draggable
       v-on:drag = "drag"
       v-on:dragend = "drop"
       v-on:dragstart = "dragStart"
     >
       <v-icon style = "margin: 4px" small @click = "$emit('remove-class',classInfo)">cancel</v-icon>
-      <v-card-text>{{classInfo.id}}: {{classInfo.title}}</v-card-text>
+      <v-card-text class="card-text"><b>{{classInfo.id}}:</b> {{classInfo.title}}</v-card-text>
 
 <!--
      <v-container
@@ -27,10 +27,25 @@
 export default {
   name: "class",
   props: ['classInfo','semesterIndex'],
+  computed: {
+    courseColor () {
+      let course  = this.classInfo.id.split('.')[0]
+      if (this.validCourses.indexOf(course) !== -1) {
+        return 'course-' + course
+      } else {
+        return 'course-none'
+      }
+    }
+  },
   data() {
     return {
       isSatisfied: true,
-      dragSemesterNum: -1
+      dragSemesterNum: -1,
+      validCourses: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10',
+        '11', '12', '14', '15', '16', '17', '18', '20', '21', '21A', '21W',
+        'CMS', '21G', '21H', '21L', '21M', 'WGS', '22', '24', 'CC', 'CSB',
+        'EC', 'EM', 'ES', 'HST', 'IDS', 'MAS', 'SCM', 'STS', 'SWE', 'SP'
+      ]
     }
   },
   methods: {
@@ -60,6 +75,11 @@ export default {
 
 
 <style scoped>
+  .card-text {
+    color: white;
+    font-size: 1.1em;
+  }
+
 /*  .classbox {
     padding: 1rem 2rem;
     border-style: solid;
@@ -74,4 +94,50 @@ export default {
   .unsatisfied {
     background: #eb7e7e;
   }
+
+  /* Colors obtained from
+  https://github.com/venkatesh-sivaraman/fireroad-server/blob/develop/requirements/static/requirements/css/req_preview.css */
+  .course-none { background-color: #999; }
+
+  .course-1 { background-color: #DE4343; }
+  .course-2 { background-color: #DE7643; }
+  .course-3 { background-color: #4369DE; }
+  .course-4 { background-color: #57B563; }
+  .course-5 { background-color: #43DEAF; }
+  .course-6 { background-color: #4390DE; }
+  .course-7 { background-color: #5779B5; }
+  .course-8 { background-color: #8157B5; }
+  .course-9 { background-color: #8143DE; }
+  .course-10 { background-color: #B55757; }
+  .course-11 { background-color: #B55773; }
+  .course-12 { background-color: #43DE4F; }
+  .course-14 { background-color: #DE9043; }
+  .course-15 { background-color: #B55C57; }
+  .course-16 { background-color: #43B2DE; }
+  .course-17 { background-color: #DE43B7; }
+  .course-18 { background-color: #575DB5; }
+  .course-20 { background-color: #57B56E; }
+  .course-21 { background-color: #57B567; }
+  .course-21A { background-color: #57B573; }
+  .course-21W { background-color: #57B580; }
+  .course-CMS { background-color: #57B58C; }
+  .course-21G { background-color: #57B599; }
+  .course-21H { background-color: #57B5A5; }
+  .course-21L { background-color: #57B5B2; }
+  .course-21M { background-color: #57ACB5; }
+  .course-WGS { background-color: #579FB5; }
+  .course-22 { background-color: #B55757; }
+  .course-24 { background-color: #7657B5; }
+  .course-CC { background-color: #4FDE43; }
+  .course-CSB { background-color: #579AB5; }
+  .course-EC { background-color: #76B557; }
+  .course-EM { background-color: #576EB5; }
+  .course-ES { background-color: #5A57B5; }
+  .course-HST { background-color: #5779B5; }
+  .course-IDS { background-color: #57B586; }
+  .course-MAS { background-color: #57B55A; }
+  .course-SCM { background-color: #57B573; }
+  .course-STS { background-color: #8F57B5; }
+  .course-SWE { background-color: #B56B57; }
+  .course-SP { background-color: #4343DE; }
 </style>


### PR DESCRIPTION
This PR adds logic that parses the department number of a class in order to assign it an appropriate color. These colors have been taken from the color scheme that `Fireroad` already uses.

Based on the comments in #29 and the discussion we had at the last `Fireroad` meeting, I've also set the following CSS rules on the text to account for the new background color changes:
```
font-size: 1.1em;
color: white;
```

This PR closes #29.