### PR TITLE
Style class search results for dragging

### DIFF
--- a/src/components/ClassSearch.vue
+++ b/src/components/ClassSearch.vue
@@ -23,13 +23,13 @@
             <v-hover>
               <tr
                 slot-scope="{ hover }"
-                :class="{ 'elevation-5': hover }"
+                :class="{ 'elevation-3': hover }"
                 draggable = "true"
                 v-on:dragend ="drop($event, props)"
                 v-on:drag = "drag($event, props)"
                 v-on:dragstart="dragStart($event, props)"
                 @click = "viewClassInfo(props)"
-                style="cursor: grab; margin: 10px; display: block;"
+                style="cursor: grab; margin: 4px; display: block;"
               >
                 <td style="padding: 0; white-space: nowrap; width: 30%;">
                   <v-icon style="vertical-align: middle;">drag_indicator</v-icon>


### PR DESCRIPTION
This PR adds logic that handles hovering over results in the `ClassSearch` component. Namely, it does the following things:
- Changes the cursor to a grabbing cursor when hovering over.
- Causes the results to "float" when hovering over them.
- Adds a small indicator on the left of each result indicating that things can get dragged.

As mentioned at the last meeting, there are a few qualms with these changes:
- The `tr` items are set to `display: block` in order for the `elevation-5` class to be applied properly. This causes a few issues with display of text for some weird reason.
- The table borders are a bit weird due to how the `padding` is set up for the `elevation-5` class to be applied.