### PR TITLE
Audit text improvements

### DIFF
--- a/src/components/Requirement.vue
+++ b/src/components/Requirement.vue
@@ -23,7 +23,7 @@
       <span v-if = "'title' in req">| </span>
       <span style = "text-transform: cursive">{{ req.req }}</span>
     </span>
-    <span v-if = "req.max === 0" style = "font-style:italic">
+    <span v-if = "req.max === 0 && leaf" style = "font-style:italic">
        (optional)
     </span>
     <div :class = "percentage_bar" :style = "percentage"></div>


### PR DESCRIPTION
Added additional text and conditions to address issues in #93 

- | only shows if there is a title before it
- Shows (optional) if the requirement is optional (icon still shows as completed, but I think we are redoing icons anyway so we can address this elsewhere).