### PR TITLE
Added audit to refactor of dragging

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -106,6 +106,7 @@
             v-bind:genericCourses = "genericCourses"
             v-bind:genericIndex = "genericIndexDict"
             @drag-class = "testClass"
+            @drag-start-class = "dragStartClass"
             @drop-class = "dropClass"
             @add-req = "addReq"
             @remove-req = "removeReq"

--- a/src/components/Audit.vue
+++ b/src/components/Audit.vue
@@ -32,6 +32,7 @@
           v-bind:genericCourses = "genericCourses"
           v-bind:genericIndex = "genericIndex"
           @drag-class = "$emit('drag-class',$event)"
+          @drag-start-class = "$emit('drag-start-class',$event)"
           @drop-class = "$emit('drop-class',$event)"
         >
         </requirement>

--- a/src/components/Requirement.vue
+++ b/src/components/Requirement.vue
@@ -106,6 +106,11 @@ export default {
     },
     dragStart: function(event) {
       event.dataTransfer.setData('foo', 'bar');
+      this.$emit('drag-start-class', {
+        dragstart: event,
+        classInfo: this.classInfo,
+        isNew: true
+      })
     }
   }
 }


### PR DESCRIPTION
Sorry about this, should've been in #104 but I lost track of which things had already been merged with what.  This just adds the drag start function to audit requirements and emits it up to App.vue so you can see semester colors while dragging.