### PR TITLE
Equivalent subjects

### DIFF
--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -272,9 +272,7 @@ export default {
           }
         }
       }
-      console.log(reqString);
       var reqExpression = splitReq.join("").replace(/\//g,"||").replace(/,/g,"&&");
-      console.log(reqExpression);
       //i know this seems scary, but the above code guarantees there will only be ()/, true false in this string
       return eval(reqExpression);
     },


### PR DESCRIPTION
6.00 counts for either 6.0001 or 6.0002
6.0001 and 6.0002 taken together count as 6.00
(calculated in the same way as fireroad is)

These changes take effect only in determining whether to display the warning, _not_ in the info card (it will still say 6.00 required even if you satisfied it by taking 6.0001 and 6.0002), otherwise it might get confusing.

Fixes #135 