### PR TITLE
Justify searchbar

### DIFF
--- a/src/pages/MainPage.vue
+++ b/src/pages/MainPage.vue
@@ -70,7 +70,7 @@
         @set-sem="setSemester"
       />
 
-      <v-layout grow>
+      <v-layout>
         <v-menu
           v-model="showSearch"
           attach
@@ -687,4 +687,9 @@ export default {
   .expanded-search {
     max-width: 22em;
   }
+</style>
+<style>
+.v-menu__activator {
+  justify-content: flex-end;
+}
 </style>


### PR DESCRIPTION
Justifies the searchbar to the right again
Not 100% sure if it's bad to have both scoped and non-scoped styles but wasn't able to figure out the css on this without directly modifying the classes vuetify produces.  This is probably bad anyway, but none of the vuetify-supplied things were working for me.