### PR TITLE
Support CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+
+node_js:
+  - "10"
+
+script: npm run lint


### PR DESCRIPTION
This PR adds a configuration for `Travis CI` so that we can run checks on things like linting before we merge PRs.

Note that right now, we probably don't want to enforce passage on `CI` yet since we're still patching up some of the linting rules.

~I'm leaving this as a PR since builds are only triggered on PRs and not on branches. Once this is ready, I'll edit this PR indicating it is okay to merge.~
~I got this PR to build. Can someone else also either open a PR or push/force-push to an existing PR to see if they can also trigger `Travis CI`? If it works, we're ready to merge.~
We might just need to merge this to see if this works. None of the other pushes will trigger a `CI` build since right now the other branches don't have a copy of `.travis.yml` for the `CI` server to use.