### PR TITLE
fix default year

### DIFF
--- a/src/components/Auth.vue
+++ b/src/components/Auth.vue
@@ -153,10 +153,11 @@ export default {
       const headerList = { headers: {
         'Authorization': 'Bearer ' + this.accessInfo.access_token
       } };
+      const currentMonth = new Date().getMonth();
       return axios.get(process.env.FIREROAD_URL + '/verify/', headerList)
         .then(function (verifyResponse) {
           if (verifyResponse.data.success) {
-            this.$emit('set-sem', verifyResponse.data.current_semester - 1);
+            this.$emit('set-sem', verifyResponse.data.current_semester - (currentMonth === 4 ? 1 : 0));
             return verifyResponse.data;
           } else {
             this.logoutUser();
@@ -489,7 +490,7 @@ export default {
       const sem = currentMonth >= 5 && currentMonth <= 10
         ? 1 + year * 3
         : 3 + year * 3;
-      this.postSecure('/set_semester/', { semester: sem + 1 }).then(function (res) {
+      this.postSecure('/set_semester/', { semester: sem + (currentMonth === 4 ? 1 : 0) }).then(function (res) {
         if (res.status === 200 && res.data.success) {
           this.$emit('set-sem', sem);
         }

--- a/src/components/Auth.vue
+++ b/src/components/Auth.vue
@@ -156,7 +156,7 @@ export default {
       return axios.get(process.env.FIREROAD_URL + '/verify/', headerList)
         .then(function (verifyResponse) {
           if (verifyResponse.data.success) {
-            this.$emit('set-sem', verifyResponse.data.current_semester);
+            this.$emit('set-sem', verifyResponse.data.current_semester - 1);
             return verifyResponse.data;
           } else {
             this.logoutUser();
@@ -486,10 +486,10 @@ export default {
     },
     changeSemester: function (year) {
       const currentMonth = new Date().getMonth();
-      const sem = currentMonth >= 4 && currentMonth <= 10
+      const sem = currentMonth >= 5 && currentMonth <= 10
         ? 1 + year * 3
         : 3 + year * 3;
-      this.postSecure('/set_semester/', { semester: sem }).then(function (res) {
+      this.postSecure('/set_semester/', { semester: sem + 1 }).then(function (res) {
         if (res.status === 200 && res.data.success) {
           this.$emit('set-sem', sem);
         }

--- a/src/components/Auth.vue
+++ b/src/components/Auth.vue
@@ -117,7 +117,6 @@ export default {
     if (this.$cookies.isKey('accessInfo')) {
       this.loggedIn = true;
       this.accessInfo = this.$cookies.get('accessInfo');
-      this.$emit('set-sem', this.accessInfo.current_semester);
       this.verify();
       this.allowCookies();
       this.getUserData();

--- a/src/components/Road.vue
+++ b/src/components/Road.vue
@@ -83,7 +83,7 @@ export default {
     baseYear: function () {
       const today = new Date();
       const currentYear = today.getFullYear();
-      const baseYear = (today.getMonth() >= 4 && today.getMonth() <= 10) ? currentYear + 1 : currentYear;
+      const baseYear = (today.getMonth() >= 5 && today.getMonth() <= 10) ? currentYear + 1 : currentYear;
       return baseYear - Math.floor((this.currentSemester - 1) / 3);
     }
   }

--- a/src/components/Road.vue
+++ b/src/components/Road.vue
@@ -86,11 +86,6 @@ export default {
       const baseYear = (today.getMonth() >= 4 && today.getMonth() <= 10) ? currentYear + 1 : currentYear;
       return baseYear - Math.floor((this.currentSemester - 1) / 3);
     }
-  },
-  watch: {
-    currentSemester: function (newSem, oldSem) {
-      this.numSems = newSem >= 13 ? 16 : 13;
-    }
   }
 };
 </script>

--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -10,9 +10,9 @@
         <v-flex xs6>
           <span style="width: 6em; display: inline-block;">
             <b>
-              {{ semesterType }}
               <v-hover>
                 <span slot-scope="{ hover }" :class="hover && 'hovering'" @click="changeYear">
+                  {{ semesterType }}
                   {{ semesterYear }}
                 </span>
               </v-hover>

--- a/src/pages/MainPage.vue
+++ b/src/pages/MainPage.vue
@@ -589,7 +589,7 @@ export default {
       this.$refs.authcomponent.updateRemote(id);
     },
     setSemester: function (sem) {
-      this.currentSemester = sem;
+      this.currentSemester = Math.max(1, sem);
     },
     pushClassStack: function (id) {
       if (id in this.subjectsIndexDict || id in this.genericIndexDict) {

--- a/src/pages/MainPage.vue
+++ b/src/pages/MainPage.vue
@@ -328,9 +328,6 @@ export default {
       searchOpen: false,
       searchX: undefined,
       searchY: undefined,
-      // TODO: Really we should grab this from a global datastore
-      // now in the same format as FireRoad
-
       // note for later: will need to use Vue.set on roads for reactivity once they come from fireroad
       roads: {
         '$defaultroad$': {

--- a/src/pages/MainPage.vue
+++ b/src/pages/MainPage.vue
@@ -320,7 +320,7 @@ export default {
       searchInput: '',
       showSearch: false,
       classInfoStack: [],
-      currentSemester: 0,
+      currentSemester: 1,
       addingFromCard: false,
       itemAdding: undefined,
       dismissedOld: false,


### PR DESCRIPTION
fixes #221 
also a temporary fix for #238 

~The reason it's showing fall 2019 now is because the default semester is 0 and the math to figure out when that is works. Unfortunately that means we'll have to use a different cue for whether they've manually set their roads or not, which is probably better anyways (going to the source).~
Makes default semester 1. Rolls year and class-classification over at the end of May instead of end of April. Doesn't mess with the way FireRoad does it by adding/subtracting 1 when saving/getting current year during May only.

I also removed some code that was chopping off your last semester if you change your year.