### PR TITLE
Subjects with prereq

### DIFF
--- a/src/components/ClassInfo.vue
+++ b/src/components/ClassInfo.vue
@@ -232,8 +232,9 @@ export default {
     subjectsWithPrereq: function() {
       const currentID = this.currentSubject.subject_id;
       const currentDept = currentID.substring(0,currentID.indexOf("."));
+      var IDMatcher = new RegExp('(?<!\\d)'+currentID.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '(?![\\da-zA-Z])');
       return this.subjects.filter(function(s) {
-        return s.prerequisites !== undefined && s.prerequisites.indexOf(currentID) >= 0;
+        return s.prerequisites !== undefined && IDMatcher.test(s.prerequisites);
       }).sort(function(s1, s2) {
         //show subjects in same department first
         var dept1 = s1.subject_id.substring(0, s1.subject_id.indexOf("."));

--- a/src/components/ClassInfo.vue
+++ b/src/components/ClassInfo.vue
@@ -186,6 +186,10 @@
               <h3>Related subjects</h3>
               <subject-scroll :subjects="currentSubject.related_subjects.map(classInfo)" @click-subject="clickRelatedSubject" />
             </div>
+            <div v-if = "subjectsWithPrereq.length > 0">
+              <h3>Subjects with {{currentSubject.subject_id}} as Prerequisite</h3>
+              <subject-scroll :subjects="subjectsWithPrereq" @click-subject = "clickRelatedSubject"></subject-scroll>
+            </div>
           </div>
         </v-card-text>
       </v-card>
@@ -224,6 +228,22 @@ export default {
       return this.currentSubject.corequisites !== undefined
         ? this.parseRequirements(this.currentSubject.corequisites)
         : { reqs: [] };
+    },
+    subjectsWithPrereq: function() {
+      const currentID = this.currentSubject.subject_id;
+      const currentDept = currentID.substring(0,currentID.indexOf("."));
+      return this.subjects.filter(function(s) {
+        return s.prerequisites !== undefined && s.prerequisites.indexOf(currentID) >= 0;
+      }).sort(function(s1, s2) {
+        //show subjects in same department first
+        var dept1 = s1.subject_id.substring(0, s1.subject_id.indexOf("."));
+        var dept2 = s2.subject_id.substring(0, s2.subject_id.indexOf("."));
+        if(dept1 === currentDept && dept2 !== currentDept) {
+          return -1;
+        } else {
+          return 0;
+        }
+      })
     }
   },
   methods: {


### PR DESCRIPTION
Still working on my P1 but was making my road and frustrated this wasn't a feature yet.

- Adds another subject scroller in the class info card with subjects that have given subject as a prereq

Does not:
- Check for equivalence pairs/sets
(Unclear how these should be handled - should we show classes with 6.00 as a prereq under 6.0001? )
- Check if prereq is necessary or one of many you can take (I think we should show it in either case anyway)

