### PR TITLE
Unscope style and make css selector more specific so it wins

### DIFF
--- a/src/components/RoadTabs.vue
+++ b/src/components/RoadTabs.vue
@@ -151,9 +151,9 @@ export default {
 };
 </script>
 
-<style scoped>
+<style>
 /*This is to prevent it from monopolizing all the space*/
-.v-tabs__container {
+div.v-tabs__container {
   display: unset;
   white-space: unset;
 }


### PR DESCRIPTION
Fixes #245 

A little wary about unscoping the style but there is no other easy way to select the generated html.