### PR TITLE
Fix audit dropping majors

### DIFF
--- a/src/pages/MainPage.vue
+++ b/src/pages/MainPage.vue
@@ -508,11 +508,13 @@ export default {
     },
     addReq: function (event) {
       this.roads[this.activeRoad].contents.coursesOfStudy.push(event);
+      this.roads[this.activeRoad].changed = moment().format(DATE_FORMAT);
       Vue.set(this.roads, this.activeRoad, this.roads[this.activeRoad]);
     },
     removeReq: function (event) {
       const reqIndex = this.roads[this.activeRoad].contents.coursesOfStudy.indexOf(event);
       this.roads[this.activeRoad].contents.coursesOfStudy.splice(reqIndex, 1);
+      Vue.set(this.roads[this.activeRoad], 'changed', moment().format(DATE_FORMAT));
     },
     setActiveRoad: function () {
       const roadHash = window.location.hash;


### PR DESCRIPTION
Fixes #188.

Sets changed field when reqs are added or removed.  Tested a few times and I don't see the dropping behavior anymore, so I think that was the problem.

I could add functionality where it only saves once you click the save button (as mentioned in comments of #188) but at this time I don't think we should remove autosave functionality and people could easily get confused by this.