### PR TITLE
Audit structure

### DIFF
--- a/src/components/Audit.vue
+++ b/src/components/Audit.vue
@@ -347,13 +347,7 @@ export default {
 }
 </style>
 <style>
-div.v-treeview-node.v-treeview-node--click {
+div.v-treeview-node.v-treeview-node--leaf {
   margin-left: 26px;
-}
-div.v-treeview {
-  margin-left: -26px;
-}
-div.v-treeview > div.v-treeview-node--click.v-treeview-node--leaf {
-  margin-left: 52px;
 }
 </style>

--- a/src/components/Audit.vue
+++ b/src/components/Audit.vue
@@ -347,6 +347,7 @@ export default {
 }
 </style>
 <style>
+/* Makes the leaf margin consistent with the margin of expandable reqs */
 div.v-treeview-node.v-treeview-node--leaf {
   margin-left: 26px;
 }

--- a/src/components/Audit.vue
+++ b/src/components/Audit.vue
@@ -346,3 +346,14 @@ export default {
   cursor: default;
 }
 </style>
+<style>
+div.v-treeview-node.v-treeview-node--click {
+  margin-left: 26px;
+}
+div.v-treeview {
+  margin-left: -26px;
+}
+div.v-treeview > div.v-treeview-node--click.v-treeview-node--leaf {
+  margin-left: 52px;
+}
+</style>


### PR DESCRIPTION
Fixes #148.

Makes margin for leaf reqs consistent with other margins.  Not super happy about css selecting generated html, or about the hardcoded 26px, but I think there's not much other way to do this.