### PR TITLE
remove all lint errors

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-new */
 import Vue from 'vue';
 import App from './App.vue';
 import MainPage from './pages/MainPage.vue';

--- a/src/components/Auth.vue
+++ b/src/components/Auth.vue
@@ -46,7 +46,6 @@
 <script>
 import axios from 'axios';
 import moment from 'moment';
-import Vue from 'vue';
 import UAParser from 'ua-parser-js';
 import simpleSSMixin from './../mixins/simpleSelectedSubjects.js';
 
@@ -179,7 +178,7 @@ export default {
             return verifyResponse.data;
           } else {
             this.logoutUser();
-            return Promise.reject('Token not valid');
+            return Promise.reject(new Error('Token not valid'));
           }
         }.bind(this));
     },
@@ -192,7 +191,7 @@ export default {
           ? axiosFunc(process.env.FIREROAD_URL + link, params, headerList)
           : axiosFunc(process.env.FIREROAD_URL + link, headerList);
       } else {
-        return Promise.reject('No auth information');
+        return Promise.reject(new Error('No auth information'));
       }
     },
 
@@ -246,9 +245,8 @@ export default {
           if (response.status === 200 && response.data.success) {
             return response.data.files;
           } else {
-            return Promise.reject();
+            return Promise.reject(new Error('sync request not successfull in getUserData'));
           }
-          return response;
         }).then(function (files) {
           this.renumberRoads(files);
           const fileKeys = Object.keys(files);
@@ -260,7 +258,7 @@ export default {
               agent: files[fileKeys[i]].agent,
               contents: {
                 coursesOfStudy: ['girs'],
-                selectedSubjects: Array.from(Array(16), () => new Array()),
+                selectedSubjects: Array.from(Array(16), () => []),
                 progressOverrides: {}
               }
             };
@@ -365,7 +363,7 @@ export default {
       const savePromise = this.postSecure('/sync/sync_road/', assignKeys)
         .then(function (response) {
           if (response.status !== 200) {
-            return Promise.reject('Unable to save road ' + this.oldid);
+            return Promise.reject(new Error('Unable to save road ' + this.oldid));
           } else {
             const newid = (response.data.id !== undefined ? response.data.id : this.oldid);
             if (response.data.success === false) {
@@ -481,8 +479,8 @@ export default {
       this.$store.commit('deleteRoad', roadID);
 
       if (roadID in this.newRoads) {
-        roadIndex = this.newRoads.indexOf(roadID);
-        this.newRoads.splice(roadID, 1);
+        const roadIndex = this.newRoads.indexOf(roadID);
+        this.newRoads.splice(roadIndex, 1);
       }
 
       if (this.loggedIn) {

--- a/src/components/ClassInfo.vue
+++ b/src/components/ClassInfo.vue
@@ -280,14 +280,14 @@ export default {
     parseRequirements: function (requirements) {
       // TODO: a way to make this more ETU?
       // remove spaces after commas and slashes
-      requirements = requirements.replace(/([,\/])\s+/g, '$1');
+      requirements = requirements.replace(/([,/])\s+/g, '$1');
       function getParenGroup (str) {
         if (str[0] === '(') {
           let retString = '';
           str = str.substring(1);
           let nextParen;
           let numParens = 1;
-          while (((nextParen = /[\(\)]/.exec(str)) !== null) && numParens > 0) {
+          while (((nextParen = /[()]/.exec(str)) !== null) && numParens > 0) {
             const parenIndex = nextParen.index;
             const parenType = nextParen[0];
             if (parenType === '(') {
@@ -307,7 +307,7 @@ export default {
         if (reqString[0] === '(') {
           return getParenGroup(reqString);
         } else {
-          const nextMatch = /^([^\/,]+)([\/,])(.*)/g.exec(reqString);
+          const nextMatch = /^([^/,]+)([/,])(.*)/g.exec(reqString);
           if (nextMatch !== null) {
             const nextReq = nextMatch[1];
             const restOfString = nextMatch[3];
@@ -319,7 +319,7 @@ export default {
         }
       }
       function isBaseReq (req) {
-        return /[\/\(\),]/g.exec(req) === null;
+        return /[/(),]/g.exec(req) === null;
       }
       const getClassInfo = this.classInfo;
       function parseReqs (reqString) {

--- a/src/components/ClassSearch.vue
+++ b/src/components/ClassSearch.vue
@@ -247,7 +247,9 @@ export default {
     }
   },
   mounted () {
-    this.updateMenuStyle();
+    this.$nextTick(() => {
+      this.updateMenuStyle();
+    });
 
     window.cookies = this.$cookies;
     $(window).resize(function () {

--- a/src/components/ClassSearch.vue
+++ b/src/components/ClassSearch.vue
@@ -57,7 +57,12 @@ export default {
   components: {
     'filter-set': FilterSet
   },
-  props: ['searchInput'],
+  props: {
+    searchInput: {
+      type: String,
+      required: true
+    }
+  },
   data: function () {
     return {
       dragSemesterNum: -1,
@@ -128,7 +133,6 @@ export default {
       return this.$store.state.genericCourses.concat(this.$store.state.subjectsInfo);
     },
     autocomplete: function () {
-      this.chosenFilters.nameInput = this.searchInput;
       // only display subjects if you are filtering by something
       let returnAny = false;
       for (const filterName in this.chosenFilters) {
@@ -223,6 +227,9 @@ export default {
     }
   },
   watch: {
+    searchInput (newVal) {
+      this.chosenFilters.nameInput = newVal;
+    },
     classStackExists: function (oldExists, newExists) {
       Vue.nextTick(function () {
         this.updateMenuStyle();

--- a/src/components/ClassSearch.vue
+++ b/src/components/ClassSearch.vue
@@ -134,91 +134,82 @@ export default {
       for (const filterName in this.chosenFilters) {
         returnAny = returnAny || this.chosenFilters[filterName].length;
       }
-      if (returnAny) {
-        // escapes special characters for regex in a string
-        function escapeRegExp (string) {
-          return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
-        }
-        // gets the .test function (which tests if a string matches regex) from each regex filter in a group
-        function getRegexFuncs (regexStrings) {
-          return regexStrings.map(function (rs) {
-            const r = new RegExp(rs, 'i');
-            const t = r.test.bind(r);
-            return t;
-          });
-        }
-        // gets a function that returns true if a string is true
-        // replaces $ in the string with the input (value of an attribute of the subject)
-        function getMathFuncs (mathStrings) {
-          return mathStrings.map(function (ms) {
-            return function (input) {
-              return eval(this.ms.replace(/\$/g, input));
-            }.bind({ ms: ms });
-          });
-        }
-        // gets functions that return a boolean if a filter is true
-        const filters = {
-          'subject_id,title': getRegexFuncs([this.chosenFilters.nameInput]),
-          'gir_attribute': getRegexFuncs(this.chosenFilters.girInput),
-          'hass_attribute': getRegexFuncs(this.chosenFilters.hassInput),
-          'communication_requirement': getRegexFuncs(this.chosenFilters.ciInput),
-          'level': getRegexFuncs(this.chosenFilters.levelInput),
-          'total_units': getRegexFuncs(this.chosenFilters.unitInput)
-        };
+      if (!returnAny) {
+        return [];
+      }
+
+      // escapes special characters for regex in a string
+      function escapeRegExp (string) {
+        return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+      }
+      // gets the .test function (which tests if a string matches regex) from each regex filter in a group
+      function getRegexFuncs (regexStrings) {
+        return regexStrings.map(function (rs) {
+          const r = new RegExp(rs, 'i');
+          const t = r.test.bind(r);
+          return t;
+        });
+      }
+      // gets functions that return a boolean if a filter is true
+      const filters = {
+        'subject_id,title': getRegexFuncs([this.chosenFilters.nameInput]),
+        'gir_attribute': getRegexFuncs(this.chosenFilters.girInput),
+        'hass_attribute': getRegexFuncs(this.chosenFilters.hassInput),
+        'communication_requirement': getRegexFuncs(this.chosenFilters.ciInput),
+        'level': getRegexFuncs(this.chosenFilters.levelInput),
+        'total_units': getRegexFuncs(this.chosenFilters.unitInput)
+      };
         // and or or function based on filter mode
-        const filterAction = this.filterGroupModes[this.filterGroupMode];
-        const filteredSubjects = this.allSubjects.filter(function (subject) {
-          for (const attrs in filters) {
-            // each test function in a filter group
-            const testers = filters[attrs];
-            if (testers.length) {
-              // if a single attribute group in a set returns true, the filter will match it
-              let passesAnyAttributeGroupInSet = false;
-              const attrSet = attrs.split(',');
-              for (let a = 0; a < attrSet.length; a++) {
-                const attr = attrSet[a];
-                let subjectattr = subject[attr];
-                if (!subject[attr]) {
-                  subjectattr = '';
-                }
-                // start with false for OR mode, and true for AND mode
-                let passesAttributeGroup = !filterAction(false, true);
-                // use the filter mode function (OR or AND) and test all filters in a group
-                for (let t = 0; t < testers.length; t++) {
-                  passesAttributeGroup = filterAction(passesAttributeGroup, testers[t](subjectattr));
-                }
-                if (passesAttributeGroup) {
-                  passesAnyAttributeGroupInSet = true;
-                }
+      const filterAction = this.filterGroupModes[this.filterGroupMode];
+      const filteredSubjects = this.allSubjects.filter(function (subject) {
+        for (const attrs in filters) {
+          // each test function in a filter group
+          const testers = filters[attrs];
+          if (testers.length) {
+            // if a single attribute group in a set returns true, the filter will match it
+            let passesAnyAttributeGroupInSet = false;
+            const attrSet = attrs.split(',');
+            for (let a = 0; a < attrSet.length; a++) {
+              const attr = attrSet[a];
+              let subjectattr = subject[attr];
+              if (!subject[attr]) {
+                subjectattr = '';
               }
-              // if the subject passes no attribute group in the set, don't include it
-              if (!passesAnyAttributeGroupInSet) {
-                return false;
+              // start with false for OR mode, and true for AND mode
+              let passesAttributeGroup = !filterAction(false, true);
+              // use the filter mode function (OR or AND) and test all filters in a group
+              for (let t = 0; t < testers.length; t++) {
+                passesAttributeGroup = filterAction(passesAttributeGroup, testers[t](subjectattr));
+              }
+              if (passesAttributeGroup) {
+                passesAnyAttributeGroupInSet = true;
               }
             }
+            // if the subject passes no attribute group in the set, don't include it
+            if (!passesAnyAttributeGroupInSet) {
+              return false;
+            }
           }
-          return true;
-        });
-        if (this.chosenFilters.nameInput.length) {
-          const sortingOrder = [this.chosenFilters.nameInput, '^' + this.chosenFilters.nameInput, escapeRegExp(this.chosenFilters.nameInput), '^' + escapeRegExp(this.chosenFilters.nameInput)];
-          const sortingFuncs = getRegexFuncs(sortingOrder);
-          const getOrderForString = function (matchingString) {
-            const matches = sortingFuncs.map((func) => func(matchingString));
-            return matches.lastIndexOf(true);
-          };
-          const getOrder = function (subject) {
-            const idMatch = getOrderForString(subject.subject_id);
-            const nameMatch = getOrderForString(subject.title);
-            return Math.max(idMatch, nameMatch);
-          };
-          return filteredSubjects.sort(function (subject1, subject2) {
-            return getOrder(subject2) - getOrder(subject1);
-          });
-        } else {
-          return filteredSubjects;
         }
+        return true;
+      });
+      if (this.chosenFilters.nameInput.length) {
+        const sortingOrder = [this.chosenFilters.nameInput, '^' + this.chosenFilters.nameInput, escapeRegExp(this.chosenFilters.nameInput), '^' + escapeRegExp(this.chosenFilters.nameInput)];
+        const sortingFuncs = getRegexFuncs(sortingOrder);
+        const getOrderForString = function (matchingString) {
+          const matches = sortingFuncs.map((func) => func(matchingString));
+          return matches.lastIndexOf(true);
+        };
+        const getOrder = function (subject) {
+          const idMatch = getOrderForString(subject.subject_id);
+          const nameMatch = getOrderForString(subject.title);
+          return Math.max(idMatch, nameMatch);
+        };
+        return filteredSubjects.sort(function (subject1, subject2) {
+          return getOrder(subject2) - getOrder(subject1);
+        });
       } else {
-        return [];
+        return filteredSubjects;
       }
     },
     classInfoStack () {

--- a/src/components/ConflictDialog.vue
+++ b/src/components/ConflictDialog.vue
@@ -57,34 +57,6 @@
 </template>
 
 <script>
-Array.prototype.diff = function (a) {
-  return this.filter(function (i) {
-    return a.indexOf(i) === -1;
-  });
-};
-
-Array.prototype.count = function (elem) {
-  let countElem = 0;
-  for (let i = 0; i < this.length; i++) {
-    if (this[i] === elem) {
-      countElem++;
-    }
-  }
-  return countElem;
-};
-
-Array.prototype.renumberDuplicates = function () {
-  return this.map(function (elem, index) {
-    if (this.count(elem) > 1) {
-      const appendNumber = this.slice(0, index).count(elem);
-      return elem + '-' + appendNumber.toString();
-    } else {
-      return elem;
-    }
-  }.bind(this));
-};
-window.Array = Array;
-
 export default {
   name: 'ConflictDialog',
   props: ['conflictInfo'],
@@ -106,25 +78,49 @@ export default {
       this.conflictDialog = false;
     },
     colorSubject: function (subjectIndex, subjectList) {
-      const remoteSubjects = this.conflictInfo.other_contents.selectedSubjects.map(
+      const remoteSubjects = this.renumberDuplicates(this.conflictInfo.other_contents.selectedSubjects.map(
         s => s.id + ' ' + s.semester
-      ).renumberDuplicates();
-      const localSubjects = this.roads[this.conflictInfo.id].contents.selectedSubjects.map(
+      ));
+      const localSubjects = this.renumberDuplicates(this.roads[this.conflictInfo.id].contents.selectedSubjects.map(
         s => s.id + ' ' + s.semester
-      ).renumberDuplicates();
+      ));
       let currentSubject;
       if (subjectList === 'remote') {
         currentSubject = remoteSubjects[subjectIndex];
-        if (remoteSubjects.diff(localSubjects).indexOf(currentSubject) >= 0) {
+        if (this.diff(remoteSubjects, localSubjects).indexOf(currentSubject) >= 0) {
           return 'blue--text';
         }
       } else if (subjectList === 'local') {
         currentSubject = localSubjects[subjectIndex];
-        if (localSubjects.diff(remoteSubjects).indexOf(currentSubject) >= 0) {
+        if (this.diff(localSubjects, remoteSubjects).indexOf(currentSubject) >= 0) {
           return 'blue--text';
         }
       }
       return '';
+    },
+    diff: function (a1, a2) {
+      return a1.filter(function (i) {
+        return a2.indexOf(i) === -1;
+      });
+    },
+    count: function (arr, elem) {
+      let countElem = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (arr[i] === elem) {
+          countElem++;
+        }
+      }
+      return countElem;
+    },
+    renumberDuplicates: function (arr) {
+      return arr.map((elem, index) => {
+        if (this.count(arr, elem) > 1) {
+          const appendNumber = this.count(arr.slice(0, index), elem);
+          return elem + '-' + appendNumber.toString();
+        } else {
+          return elem;
+        }
+      });
     }
   }
 };

--- a/src/components/RoadTabs.vue
+++ b/src/components/RoadTabs.vue
@@ -108,13 +108,9 @@
 </template>
 
 <script>
-import Road from './Road.vue';
-
 export default {
   name: 'RoadTabs',
   components: {
-    // TODO: This is not used?
-    'road': Road
   },
   data: function () {
     return {

--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -208,13 +208,12 @@ export default {
             textColor: 'DarkGoldenRod'
           };
         }
-      } else {
-        return {
-          bgColor: 'grey',
-          message: '',
-          textColor: ''
-        };
       }
+      return {
+        bgColor: 'grey',
+        message: '',
+        textColor: ''
+      };
     },
     isSameYear: function () {
       return Math.floor((this.index - 1) / 3) === Math.floor((this.currentSemester - 1) / 3);
@@ -403,6 +402,7 @@ export default {
       }
       const reqExpression = splitReq.join('').replace(/\//g, '||').replace(/,/g, '&&');
       // i know this seems scary, but the above code guarantees there will only be ()/, true false in this string
+      // eslint-disable-next-line no-eval
       return eval(reqExpression);
     },
     dragenter: function (event) {

--- a/src/mixins/simpleSelectedSubjects.js
+++ b/src/mixins/simpleSelectedSubjects.js
@@ -1,7 +1,7 @@
 export default {
   methods: {
     getSimpleSelectedSubjects (selectedSubjects) {
-      const simpless = Array.from(Array(16), () => new Array());
+      const simpless = Array.from(Array(16), () => []);
       for (let i = 0; i < selectedSubjects.length; i++) {
         const s = selectedSubjects[i];
         if (s.semester === undefined || s.semester < 0) {

--- a/src/pages/MainPage.vue
+++ b/src/pages/MainPage.vue
@@ -147,7 +147,7 @@
     </v-content>
 
     <v-card
-      v-if="searchOpen"
+      v-show="searchOpen"
       id="searchMenuCard"
       class="elevation-8"
       @click.native="$event.stopPropagation();"

--- a/src/pages/MainPage.vue
+++ b/src/pages/MainPage.vue
@@ -208,7 +208,6 @@
 import Audit from './../components/Audit.vue';
 import ClassSearch from './../components/ClassSearch.vue';
 import Road from './../components/Road.vue';
-import FilterSet from './../components/FilterSet.vue';
 import RoadTabs from './../components/RoadTabs.vue';
 import ConflictDialog from './../components/ConflictDialog.vue';
 import Auth from './../components/Auth.vue';
@@ -227,7 +226,6 @@ export default {
     'audit': Audit,
     'class-search': ClassSearch,
     'road': Road,
-    'filter-set': FilterSet,
     'road-tabs': RoadTabs,
     'conflict-dialog': ConflictDialog,
     'auth': Auth,
@@ -420,7 +418,7 @@ export default {
       window.location.hash = '#/#road' + this.activeRoad;
       return false;
     },
-    addRoad: function (roadName, cos = ['girs'], ss = Array.from(Array(16), () => new Array()), overrides = {}) {
+    addRoad: function (roadName, cos = ['girs'], ss = Array.from(Array(16), () => []), overrides = {}) {
       const tempRoadID = '$' + this.$refs.authcomponent.newRoads.length + '$';
       const newContents = {
         coursesOfStudy: cos,

--- a/src/stores/courseData.js
+++ b/src/stores/courseData.js
@@ -25,7 +25,7 @@ const store = new Vuex.Store({
         agent: '',
         contents: {
           coursesOfStudy: ['girs'],
-          selectedSubjects: Array.from(Array(16), () => new Array()),
+          selectedSubjects: Array.from(Array(16), () => []),
           progressOverrides: {}
         }
       }


### PR DESCRIPTION
Things I wasn't sure about that need taking care of:
- [x] `Array prototype is read only, properties should not be added  no-extend-native` in `ConflictDialog.vue`: should we disable this or is that actually bad practice?
- [x] `Unexpected side effect in "autocomplete" computed property  vue/no-side-effects-in-computed-properties` in `ClassSearch.vue`: this does seem like bad practice.

Also almost every single warning is about defining prop types, so that would probably be straightforward to tackle in a subsequent PR if someone wants to take it on. I didn't do it here because the errors took long enough.