### PR TITLE
Change default expire to infinity, 3 days for login token

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -30,7 +30,7 @@ var router = new VueRouter({
   routes
 });
 
-VueCookies.config('3d');
+VueCookies.config(Infinity);
 
 new Vue({
   el: '#app',

--- a/src/components/Auth.vue
+++ b/src/components/Auth.vue
@@ -104,7 +104,7 @@ export default {
       if (newCA) {
         this.$cookies.set('newRoads', this.getNewRoadData());
         if (this.loggedIn) {
-          this.$cookies.set('accessInfo', this.accessInfo);
+          this.$cookies.set('accessInfo', this.accessInfo, '3d');
         }
         this.setTabID();
       }
@@ -327,7 +327,7 @@ export default {
         .then(function (response) {
           if (response.data.success) {
             if (this.data.cookiesAllowed) {
-              this.data.$cookies.set('accessInfo', response.data.access_info);
+              this.data.$cookies.set('accessInfo', response.data.access_info, '3d');
             }
             this.data.accessInfo = response.data.access_info;
             this.data.verify();


### PR DESCRIPTION
Fixes #290 

Cookies will last forever now, except login tokens (deleted after 3 days).

We could change this to a year or a month or so if we don't want it to last forever but 3 days for everything is really annoying because everything's reset pretty much every time you open courseroad.