### PR TITLE
Add CGI middleware for requests to People API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ public
 
 # TernJS port file
 .tern-port
+
+# Credentials for the MIT People API
+credentials.ini

--- a/build/webpack.config.dev.js
+++ b/build/webpack.config.dev.js
@@ -1,8 +1,10 @@
 'use strict'
 const webpack = require('webpack')
 const { VueLoaderPlugin } = require('vue-loader')
+const { resolve } = require('path')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
+const cgi = require('cgi')
 
 module.exports = (env) => {
   return {
@@ -14,6 +16,13 @@ module.exports = (env) => {
       hot: true,
       watchOptions: {
         poll: true
+      },
+      before: function (app, server, compiler) {
+        // Before handing all other dev server requests, check if the route is to the People API middleware and pass
+        // it to the CGI handler.
+        app.get('/cgi-bin/people.py', function (req, res) {
+          cgi(resolve(__dirname, '..', 'cgi-bin', 'people.py'))(req, res)
+        })
       }
     },
     module: {

--- a/cgi-bin/people.py
+++ b/cgi-bin/people.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python3
+from cgi import FieldStorage
+from configparser import ConfigParser
+from json import dumps, loads
+from os import path
+from requests import get
+
+args = FieldStorage()
+
+error = 'Status: 400 Bad Request\n'
+content = 'Content-Type: application/json\n\n'
+
+if 'kerb' not in args:
+    output = {"error": "kerb was not specified"}
+    print(error + content)
+    print(dumps(output))
+else:
+    c = ConfigParser()
+    try:
+        with open(path.join(path.dirname(path.realpath(__file__)), 'credentials.ini')) as fp:
+            c.read_file(fp)
+        response = get('https://mit-people-v3.cloudhub.io/people/v3/people/{0}'.format(args['kerb'].value), headers={'client_id': c['Credentials']['ID'], 'client_secret': c['Credentials']['Secret']})
+        if response.status_code != 200:
+            output = {"error": "could not get user data"}
+            print(error + content)
+            print(dumps(output))
+        else:
+            data = loads(response.text)
+            if data['item']['affiliations'][0]['type'] != "student":
+                output = {"error": "user is not a student"}
+                print(error + content)
+                print(dumps(output))
+            else:
+                year = data['item']['affiliations'][0]['classYear']
+                if year == "G":
+                    output = {"error": "user is a graduate student (currently unhandled)"}
+                    print(error + content)
+                    print(dumps(output))
+                else:
+                    year = int(year)
+                    year = year - 1
+                    output = {"year": year}
+                    print(content)
+                    print(dumps(output))
+    except Exception:
+        output = {"error": "could not read credentials"}
+        print(error + content)
+        print(dumps(output))

--- a/cgi-bin/people.py
+++ b/cgi-bin/people.py
@@ -8,12 +8,11 @@ from requests import get
 args = FieldStorage()
 
 error = 'Status: 400 Bad Request\n'
-content = 'Content-Type: application/json\n\n'
+header = 'Content-Type: application/json\n\n'
 
 if 'kerb' not in args:
     output = {"error": "kerb was not specified"}
-    print(error + content)
-    print(dumps(output))
+    header = error + header
 else:
     c = ConfigParser()
     try:
@@ -21,28 +20,25 @@ else:
             c.read_file(fp)
         response = get('https://mit-people-v3.cloudhub.io/people/v3/people/{0}'.format(args['kerb'].value), headers={'client_id': c['Credentials']['ID'], 'client_secret': c['Credentials']['Secret']})
         if response.status_code != 200:
+            header = error + header
             output = {"error": "could not get user data"}
-            print(error + content)
-            print(dumps(output))
         else:
             data = loads(response.text)
             if data['item']['affiliations'][0]['type'] != "student":
+                header = error + header
                 output = {"error": "user is not a student"}
-                print(error + content)
-                print(dumps(output))
             else:
                 year = data['item']['affiliations'][0]['classYear']
                 if year == "G":
+                    header = error + header
                     output = {"error": "user is a graduate student (currently unhandled)"}
-                    print(error + content)
-                    print(dumps(output))
                 else:
                     year = int(year)
                     year = year - 1
                     output = {"year": year}
-                    print(content)
-                    print(dumps(output))
     except Exception:
+        header = error + header
         output = {"error": "could not read credentials"}
-        print(error + content)
-        print(dumps(output))
+
+print(header)
+print(dumps(output))

--- a/deploy.sh
+++ b/deploy.sh
@@ -10,12 +10,12 @@ if [ "$1" = "prod" ]; then
   echo -n "You are about to deploy to the production site, are you sure? (y/n)? "
   read answer
   if [ "$answer" != "${answer#[Yy]}" ] ;then
-    scp -r dist/* $2@athena.dialup.mit.edu:/mit/courseroad/web_scripts/courseroad/
+    scp -r cgi-bin/ dist/* $2@athena.dialup.mit.edu:/mit/courseroad/web_scripts/courseroad/
   else
     echo cancelled
   fi
 elif [ "$1" = "dev" ]; then
-    scp -r dist/* $2@athena.dialup.mit.edu:/mit/courseroad/web_scripts/courseroad/dev/
+    scp -r cgi-bin/ dist/* $2@athena.dialup.mit.edu:/mit/courseroad/web_scripts/courseroad/dev/
 else
   echo "Invalid build location"
 fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -3720,6 +3720,16 @@
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
+    "bufferjs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bufferjs/-/bufferjs-3.0.1.tgz",
+      "integrity": "sha1-BpLoKcsQoQVQ5kc5CwNesGw46O8="
+    },
+    "bufferlist": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bufferlist/-/bufferlist-0.1.0.tgz",
+      "integrity": "sha1-Qr7y2JVztA+hCGuzng9TEBcNHd0="
+    },
     "builtin-status-codes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
@@ -3907,6 +3917,37 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
+    },
+    "cgi": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cgi/-/cgi-0.3.1.tgz",
+      "integrity": "sha1-h1HaZKHPGEnREFYxi3YNGs+6R9w=",
+      "requires": {
+        "debug": "2",
+        "extend": "~2.0.0",
+        "header-stack": "~0.0.2",
+        "stream-stack": "~1.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "extend": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.2.tgz",
+          "integrity": "sha512-AgFD4VU+lVLP6vjnlNfF7OeInLTyeyckCNPEsuxz1vi786UuK/nk6ynPuhn/h+Ju9++TQyr5EpLRI14fc1QtTQ=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
     },
     "chalk": {
       "version": "2.4.2",
@@ -7967,6 +8008,16 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
+    },
+    "header-stack": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/header-stack/-/header-stack-0.0.2.tgz",
+      "integrity": "sha1-Rg1ysW04ZSzkUeIyU2lxsx6E1g8=",
+      "requires": {
+        "bufferjs": ">= 0.2.3",
+        "bufferlist": ">= 0.0.6",
+        "stream-stack": ">= 1.1.1"
+      }
     },
     "hex-color-regex": {
       "version": "1.1.0",
@@ -14836,6 +14887,11 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
+    },
+    "stream-stack": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/stream-stack/-/stream-stack-1.1.4.tgz",
+      "integrity": "sha1-cIRgQrqwGFAI5Qnt/h93+TYcumk="
     },
     "strict-uri-encode": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "main": "index.js",
   "dependencies": {
     "axios": "^0.19.0",
+    "cgi": "^0.3.1",
     "jquery": "^3.3.1",
     "material-design-icons-iconfont": "^4.0.5",
     "moment": "^2.24.0",

--- a/src/components/Auth.vue
+++ b/src/components/Auth.vue
@@ -123,19 +123,21 @@ export default {
         const email = this.accessInfo.academic_id;
         const endPoint = email.indexOf('@');
         const kerb = email.slice(0, endPoint);
-        axios.get('https://mit-people-v3.cloudhub.io/people/v3/people/' + kerb,
-          { headers: { 'client_id': '01fce9ed7f9d4d26939a68a4126add9b',
-            'client_secret': 'D4ce51aA6A32421DA9AddF4188b93255' } })
+        axios.get(process.env.APP_URL + '/cgi-bin/people.py?kerb=' + kerb)
           .then(response => {
-            // subtract 1 for zero-indexing
-            const year = response.data.item.affiliations[0].classYear - 1;
-            if (year === undefined) {
+            if (response.status !== 200) {
               console.log('Failed to find user year');
             } else {
-              this.changeSemester(year);
+              const year = response.data.year;
+              if (year === undefined) {
+                console.log('Failed to find user year');
+              } else {
+                this.changeSemester(year);
+                console.log('setting year to ' + year);
+              }
             }
           });
-      };
+      }
     }
   },
   mounted () {


### PR DESCRIPTION
This PR adds a new `CGI` handler called `people.py` that is responsible for making requests to the `People API` on behalf of any `CourseRoad` clients. Requests can be made to this endpoint with a user's `kerb` and the API will return either an error or the year of the user zero-indexed. This resolves an issue in which the credentials for interacting with the API was stored directly in the client-side code.

This PR also modifies the logic of the `webpack-dev-server` to allow for it to run its own `CGI` handler so that this logic can be tested during development as well. For this to work properly, each person will need to obtain a copy of `credentials.ini` to set up this script (which I currently have) since these credentials will not be committed to `GitHub`.

A few changes will need to be made once this is merged into `master` to make sure this works properly, including setting up any dependencies that this `CGI` middleware requires on `Scripts`. Once this is approved by someone, I'll start testing on `dev` before deploying to production.