### PR TITLE
Fix Vue production builds

### DIFF
--- a/build/webpack.config.dev.js
+++ b/build/webpack.config.dev.js
@@ -3,9 +3,9 @@ const webpack = require('webpack')
 const { VueLoaderPlugin } = require('vue-loader')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
+
 module.exports = (env) => {
   return {
-    mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
     entry: [
       '@babel/polyfill',
       './src/app.js'
@@ -66,8 +66,7 @@ module.exports = (env) => {
         filename: 'css/app.css'
       }),
       new webpack.DefinePlugin({ 'process.env.APP_URL': JSON.stringify(env.APP_URL) }),
-      new webpack.DefinePlugin({ 'process.env.FIREROAD_URL': JSON.stringify(env.FIREROAD_URL) }),
-      new webpack.DefinePlugin({ 'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV) })
+      new webpack.DefinePlugin({ 'process.env.FIREROAD_URL': JSON.stringify(env.FIREROAD_URL) })
     ]
   }
 }


### PR DESCRIPTION
This PR fixes the `Webpack` configuration so that anytime a build is produced for either the public `development` site or the `production` site, Vue's mode is properly set to `production` to hide any debugging information. This fixes an issue in which all builds would always set Vue to run in `production` mode.