### PR TITLE
Implement history mode on vue-router

### DIFF
--- a/build/webpack.config.dev.js
+++ b/build/webpack.config.dev.js
@@ -11,6 +11,7 @@ module.exports = (env) => {
       './src/app.js'
     ],
     devServer: {
+      historyApiFallback: true,
       hot: true,
       watchOptions: {
         poll: true

--- a/build/webpack.config.dev.js
+++ b/build/webpack.config.dev.js
@@ -55,6 +55,9 @@ module.exports = (env) => {
         }
       ]
     },
+    output: {
+      publicPath: env.APP_URL.indexOf('dev') !== -1 ? '/dev/' : '/'
+    },
     plugins: [
       new webpack.HotModuleReplacementPlugin(),
       new VueLoaderPlugin(),

--- a/deploy.sh
+++ b/deploy.sh
@@ -10,12 +10,12 @@ if [ "$1" = "prod" ]; then
   echo -n "You are about to deploy to the production site, are you sure? (y/n)? "
   read answer
   if [ "$answer" != "${answer#[Yy]}" ] ;then
-    scp -r dist/* $2@athena.dialup.mit.edu:/mit/courseroad/web_scripts/courseroad/
+    scp -r deploy/production/.htaccess dist/* $2@athena.dialup.mit.edu:/mit/courseroad/web_scripts/courseroad/
   else
     echo cancelled
   fi
 elif [ "$1" = "dev" ]; then
-    scp -r dist/* $2@athena.dialup.mit.edu:/mit/courseroad/web_scripts/courseroad/dev/
+    scp -r deploy/development/.htaccess dist/* $2@athena.dialup.mit.edu:/mit/courseroad/web_scripts/courseroad/dev/
 else
   echo "Invalid build location"
 fi

--- a/deploy/development/.htaccess
+++ b/deploy/development/.htaccess
@@ -1,0 +1,1 @@
+ErrorDocument 404 /dev/index.html

--- a/deploy/production/.htaccess
+++ b/deploy/production/.htaccess
@@ -1,0 +1,1 @@
+ErrorDocument 404 /index.html

--- a/src/app.js
+++ b/src/app.js
@@ -27,7 +27,8 @@ Vue.use(BrowserSupportPlugin);
 var routes = [
   { path: '/', redirect: '/road' },
   { path: '/about', component: About },
-  { path: '/road/:road?', component: MainPage }
+  { path: '/road/:road?', component: MainPage },
+  { path: '*', redirect: '/road' }
 ];
 
 var router = new VueRouter({

--- a/src/app.js
+++ b/src/app.js
@@ -25,11 +25,13 @@ Vue.use(VueRouter);
 Vue.use(BrowserSupportPlugin);
 
 var routes = [
-  { path: '/', component: MainPage },
-  { path: '/about', component: About }
+  { path: '/', redirect: '/road' },
+  { path: '/about', component: About },
+  { path: '/road/:road?', component: MainPage }
 ];
 
 var router = new VueRouter({
+  mode: 'history',
   routes
 });
 

--- a/src/app.js
+++ b/src/app.js
@@ -32,6 +32,7 @@ var routes = [
 ];
 
 var router = new VueRouter({
+  base: process.env.APP_URL.indexOf('dev') !== -1 ? '/dev/' : '/',
   mode: 'history',
   routes
 });

--- a/src/pages/MainPage.vue
+++ b/src/pages/MainPage.vue
@@ -298,7 +298,7 @@ export default {
         this.updateFulfillment(this.$store.state.fulfillmentNeeded);
       }
       if (newRoad !== '') {
-        window.history.pushState({}, this.roads[newRoad].name, './#/#road' + newRoad);
+        this.$router.push({ path: `/road/${newRoad}` });
       }
     },
     cookiesAllowed: function (newCA) {
@@ -324,6 +324,9 @@ export default {
         }
       },
       deep: true
+    },
+    $route () {
+      this.setActiveRoad();
     }
   },
   created () {
@@ -351,10 +354,6 @@ export default {
       const scrollPosition = scrollers.scrollLeft();
       borders.css({ top: 0, left: scrollWidth - 1 + scrollPosition });
     });
-
-    $(window).on('hashchange', function () {
-      this.setActiveRoad();
-    }.bind(this));
 
     this.setActiveRoad();
 
@@ -426,15 +425,14 @@ export default {
       }
     },
     setActiveRoad: function () {
-      const roadHash = window.location.hash;
-      if (roadHash.length && roadHash.substring(0, 7) === '#/#road') {
-        const roadRequested = roadHash.substring(7);
+      if (this.roads.hasOwnProperty(this.$route.params.road)) {
+        const roadRequested = this.$route.params.road;
         if (roadRequested in this.roads) {
-          this.$store.commit('setActiveRoad', roadHash.substring(7));
+          this.$store.commit('setActiveRoad', roadRequested);
           return true;
         }
       }
-      window.location.hash = '#/#road' + this.activeRoad;
+      this.$router.push({ path: `/road/${this.activeRoad}` });
       return false;
     },
     addRoad: function (roadName, cos = ['girs'], ss = Array.from(Array(16), () => []), overrides = {}) {


### PR DESCRIPTION
This PR makes various modifications to the routing to improve how URLs are handled in `CourseRoad`:
- History mode is now used for the routing, effectively removing the need for `#` characters in the URL. Accordingly, the paths for roads are now of the format `/?road=<id>` instead of `/#/#road<id>`.
- Going backwards and forwards in the browser history both allow you to navigate between roads properly, and this logic no longer depends on `jQuery` to be operational.
- Any URLs that would return a `404` will redirect to the home page.

Accordingly, the `Webpack` configuration handles history mode properly, so that server side `404` errors will pass off handling of the error over to `CourseRoad` and its routing logic.

Once this PR is approved, I'll deploy this to `dev` and make the necessary changes to `.htaccess` on `Scripts` for this to fully work before deploying to `production`.

This PR resolves #312.