### PR TITLE
Add support for AFS deployment

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # To run this script you must have 'aklog' written in ~/.bash_environment
 # (or the environment file for whatever shell you use)
 # and 'sipb' and 'athena' written in ~/.xlog (both of these files should be in your athena locker).
@@ -5,17 +6,39 @@
 # even if you are on courseroad-dev.
 
 #syntax: ./deploy.sh [dev or prod] [kerberos]
+set -e
+
 npm run build-$1
 if [ "$1" = "prod" ]; then
   echo -n "You are about to deploy to the production site, are you sure? (y/n)? "
   read answer
-  if [ "$answer" != "${answer#[Yy]}" ] ;then
-    scp -r dist/* $2@athena.dialup.mit.edu:/mit/courseroad/web_scripts/courseroad/
+  if [ "$answer" != "${answer#[Yy]}" ]; then
+    echo "Checking for OpenAFS on this system"
+    if which aklog; then
+      echo "OpenAFS detected, using OpenAFS for deployment"
+      kinit -f -l 1h $2
+      aklog sipb
+      rsync --delete --progress --checksum -r dist/* /afs/sipb.mit.edu/project/courseroad/web_scripts/courseroad/
+      kdestroy
+    else
+      echo "Could not locate OpenAFS, using SSH for deployment"
+      scp -r dist/* $2@athena.dialup.mit.edu:/mit/courseroad/web_scripts/courseroad/
+    fi
   else
-    echo cancelled
+    echo "Cancelled"
   fi
-elif [ "$1" = "dev" ]; then
+elif [ "$1" == "dev" ]; then
+  echo "Checking for OpenAFS on this system"
+  if which aklog; then
+    echo "OpenAFS detected, using OpenAFS for deployment"
+    kinit -f -l 1h $2
+    aklog sipb
+    rsync --delete --progress --checksum -r dist/* /afs/sipb.mit.edu/project/courseroad/web_scripts/courseroad/dev/
+    kdestroy
+  else
+    echo "Could not locate OpenAFS, using SSH for deployment"
     scp -r dist/* $2@athena.dialup.mit.edu:/mit/courseroad/web_scripts/courseroad/dev/
+  fi
 else
   echo "Invalid build location"
 fi


### PR DESCRIPTION
This PR updates `deploy.sh` so that it is possible to deploy over `AFS` and avoid using `SSH`.

If the script detects `aklog`, it will assume that `AFS` is installed and authenticate with `kinit` to get a `Kerberos ticket`, authenticate to the `SIPB` cell, and use `rsync` to deploy `CourseRoad`. If not installed, this script should default back to `SSH` for deployment.