### PR TITLE
Expected hours tooltip

### DIFF
--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -27,11 +27,13 @@
               <span v-on="on">Hours: {{ semesterInformation.totalExpectedHours.toFixed(1) }}</span>
             </template>
             <div id="tooltipTable">
-              <table v-if="semesterSubjects.length" border="1">
+              <table v-if="semesterSubjects.length">
                 <tr v-if="semesterInformation.expectedHoursQuarter1.length">
                   <th v-if="semesterInformation.anyClassInSingleQuarter" rowspan="2">
                     Quarter 1 <br>
-                    <span style="font-weight:normal">{{ semesterInformation.totalExpectedHoursQuarter1.toFixed(1) }}h </span>
+                    <span style="font-weight: normal">
+                      {{ semesterInformation.totalExpectedHoursQuarter1.toFixed(1) }}h
+                    </span>
                   </th>
                   <th class="rightbar">
                     Class
@@ -54,7 +56,9 @@
                 >
                   <th rowspan="2">
                     Quarter 2 <br>
-                    <span style="font-weight:normal">{{ semesterInformation.totalExpectedHoursQuarter2.toFixed(1) }}h </span>
+                    <span style="font-weight: normal">
+                      {{ semesterInformation.totalExpectedHoursQuarter2.toFixed(1) }}h
+                    </span>
                   </th>
                   <th class="rightbar">
                     Class

--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -26,36 +26,47 @@
             <template v-slot:activator="{ on }">
               <span v-on="on">Hours: {{ semesterInformation.totalExpectedHours.toFixed(1) }}</span>
             </template>
-            <div>
+            <div id="tooltipTable">
               <table v-if="semesterSubjects.length" border="1">
                 <tr v-if="semesterInformation.expectedHoursQuarter1.length">
                   <th v-if="semesterInformation.anyClassInSingleQuarter" rowspan="2">
                     Quarter 1 <br>
                     <span style="font-weight:normal">{{ semesterInformation.totalExpectedHoursQuarter1.toFixed(1) }}h </span>
                   </th>
-                  <th>Class</th>
+                  <th class="rightbar">
+                    Class
+                  </th>
                   <td v-for="subj in semesterInformation.expectedHoursQuarter1" :key="subj.id">
-                    {{ subj.id }}
+                    <b>{{ subj.id }}</b>
                   </td>
                 </tr>
                 <tr v-if="semesterInformation.expectedHoursQuarter1.length">
-                  <th>Hours</th>
+                  <th class="rightbar">
+                    Hours
+                  </th>
                   <td v-for="subj in semesterInformation.expectedHoursQuarter1" :key="subj.id">
                     {{ subj.hours.toFixed(1) }}h
                   </td>
                 </tr>
-                <tr v-if="semesterInformation.anyClassInSingleQuarter && semesterInformation.expectedHoursQuarter2.length">
+                <tr
+                  v-if="semesterInformation.anyClassInSingleQuarter && semesterInformation.expectedHoursQuarter2.length"
+                  class="topbar"
+                >
                   <th rowspan="2">
                     Quarter 2 <br>
                     <span style="font-weight:normal">{{ semesterInformation.totalExpectedHoursQuarter2.toFixed(1) }}h </span>
                   </th>
-                  <th>Class</th>
+                  <th class="rightbar">
+                    Class
+                  </th>
                   <td v-for="subj in semesterInformation.expectedHoursQuarter2" :key="subj.id">
-                    {{ subj.id }}
+                    <b>{{ subj.id }}</b>
                   </td>
                 </tr>
                 <tr v-if="semesterInformation.anyClassInSingleQuarter && semesterInformation.expectedHoursQuarter2.length">
-                  <th>Hours</th>
+                  <th class="rightbar">
+                    Hours
+                  </th>
                   <td v-for="subj in semesterInformation.expectedHoursQuarter2" :key="subj.id">
                     {{ subj.hours.toFixed(1) }}h
                   </td>
@@ -553,5 +564,22 @@ export default {
     overflow: hidden;
     white-space: nowrap;
     color: white;
+  }
+  /* tooltip table styling */
+  #tooltipTable table {
+    border-collapse: collapse;
+    margin: 0;
+  }
+  #tooltipTable table , #tooltipTable th, #tooltipTable td {
+    border: 3px solid grey;
+  }
+  #tooltipTable th, #tooltipTable td {
+    padding: 0.4em;
+  }
+  #tooltipTable .rightbar {
+    border-right-width: 5px;
+  }
+  #tooltipTable .topbar th, #tooltipTable .topbar td {
+    border-top-width: 5px;
   }
 </style>

--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -26,6 +26,30 @@
             <template v-slot:activator="{ on }">
               <span v-on="on">Hours: {{ semesterInformation.totalExpectedHours.toFixed(1) }}</span>
             </template>
+            <template>
+              <v-data-table
+                :headers="semesterInformation.headers"
+                :items="semesterInformation.table"
+                hide-actions
+                hide-headers
+                disable-initial-sort
+                no-data-text="No classes"
+                dense
+              >
+                <template slot="items" slot-scope="props">
+                  <tr>
+                    <td v-for="property in semesterInformation.headers">
+                      <span v-if = "property.value === 'quarter'">
+                        <b>{{ props.item[property.value] }}</b>
+                      </span>
+                      <span v-else>
+                        {{ props.item[property.value]}}
+                      </span>
+                    </td>
+                  </tr>
+                </template>
+              </v-data-table>
+            </template>
             <div>
               <table v-if="semesterSubjects.length" border="1">
                 <tr v-if="semesterInformation.expectedHoursQuarter1.length">
@@ -359,6 +383,47 @@ export default {
       const totalExpectedHoursQuarter2 = expectedHoursQuarter2.reduce(sumExpectedHours, 0);
       const totalExpectedHours = Math.max(totalExpectedHoursQuarter1, totalExpectedHoursQuarter2);
       const anyClassInSingleQuarter = classesInfo.some((s) => s.quarter_information !== undefined);
+      const maxNumberOfClasses = Math.max(expectedHoursQuarter1.length, expectedHoursQuarter2.length);
+
+      let headers = [];
+      if (anyClassInSingleQuarter) {
+        headers.push({ text: 'Quarter', value: 'quarter' });
+      }
+      headers.push({ text: 'Header', value: 'header' });
+      for (var i = 0; i < maxNumberOfClasses; i++) {
+        headers.push({ text: 'Class ' + i, value: 'class-' + i });
+      }
+
+      let table = [];
+      if (expectedHoursQuarter1.length) {
+        let ids = { header: 'Class', quarter: 'Quarter 1' };
+        let hours = { header: 'Hours', quarter: totalExpectedHoursQuarter1.toFixed(1) + 'h' };
+        for (var i = 0; i < expectedHoursQuarter1.length; i++) {
+          ids['class-'+i] = expectedHoursQuarter1[i].id;
+          hours['class-'+i] = expectedHoursQuarter1[i].hours.toFixed(1) + 'h';
+        }
+        for (var i = expectedHoursQuarter1.length; i < maxNumberOfClasses; i++) {
+          ids['class-'+i] = '';
+          hours['class-i'+i] = '';
+        }
+        table.push(ids);
+        table.push(hours);
+      }
+      if (expectedHoursQuarter2.length && anyClassInSingleQuarter) {
+        let ids = { header: 'Class', quarter: 'Quarter 2' };
+        let hours = { header: 'Hours', quarter: totalExpectedHoursQuarter2.toFixed(1) + 'h' };
+        for (var i = 0; i < expectedHoursQuarter2.length; i++) {
+          ids['class-'+i] = expectedHoursQuarter2[i].id;
+          hours['class-'+i] = expectedHoursQuarter2[i].hours.toFixed(1) + 'h';
+        }
+        for (var i = expectedHoursQuarter2.length; i < maxNumberOfClasses; i++) {
+          ids['class-'+i] = '';
+          hours['class-'+i] = '';
+        }
+        table.push(ids);
+        table.push(hours);
+      }
+
       return {
         totalUnits,
         totalExpectedHours,
@@ -366,7 +431,9 @@ export default {
         expectedHoursQuarter1,
         expectedHoursQuarter2,
         totalExpectedHoursQuarter1,
-        totalExpectedHoursQuarter2
+        totalExpectedHoursQuarter2,
+        headers,
+        table
       };
     },
     semesterYearName: function () {

--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -26,30 +26,6 @@
             <template v-slot:activator="{ on }">
               <span v-on="on">Hours: {{ semesterInformation.totalExpectedHours.toFixed(1) }}</span>
             </template>
-            <template>
-              <v-data-table
-                :headers="semesterInformation.headers"
-                :items="semesterInformation.table"
-                hide-actions
-                hide-headers
-                disable-initial-sort
-                no-data-text="No classes"
-                dense
-              >
-                <template slot="items" slot-scope="props">
-                  <tr>
-                    <td v-for="property in semesterInformation.headers" :key="property">
-                      <span v-if="property.value === 'quarter'">
-                        <b>{{ props.item[property.value] }}</b>
-                      </span>
-                      <span v-else>
-                        {{ props.item[property.value] }}
-                      </span>
-                    </td>
-                  </tr>
-                </template>
-              </v-data-table>
-            </template>
             <div>
               <table v-if="semesterSubjects.length" border="1">
                 <tr v-if="semesterInformation.expectedHoursQuarter1.length">
@@ -383,46 +359,6 @@ export default {
       const totalExpectedHoursQuarter2 = expectedHoursQuarter2.reduce(sumExpectedHours, 0);
       const totalExpectedHours = Math.max(totalExpectedHoursQuarter1, totalExpectedHoursQuarter2);
       const anyClassInSingleQuarter = classesInfo.some((s) => s.quarter_information !== undefined);
-      const maxNumberOfClasses = Math.max(expectedHoursQuarter1.length, expectedHoursQuarter2.length);
-
-      const headers = [];
-      if (anyClassInSingleQuarter) {
-        headers.push({ text: 'Quarter', value: 'quarter' });
-      }
-      headers.push({ text: 'Header', value: 'header' });
-      for (var i = 0; i < maxNumberOfClasses; i++) {
-        headers.push({ text: 'Class ' + i, value: 'class-' + i });
-      }
-
-      const table = [];
-      if (expectedHoursQuarter1.length) {
-        const ids = { header: 'Class', quarter: 'Quarter 1' };
-        const hours = { header: 'Hours', quarter: totalExpectedHoursQuarter1.toFixed(1) + 'h' };
-        for (i = 0; i < expectedHoursQuarter1.length; i++) {
-          ids['class-' + i] = expectedHoursQuarter1[i].id;
-          hours['class-' + i] = expectedHoursQuarter1[i].hours.toFixed(1) + 'h';
-        }
-        for (i = expectedHoursQuarter1.length; i < maxNumberOfClasses; i++) {
-          ids['class-' + i] = '';
-          hours['class-i' + i] = '';
-        }
-        table.push(ids);
-        table.push(hours);
-      }
-      if (expectedHoursQuarter2.length && anyClassInSingleQuarter) {
-        const ids = { header: 'Class', quarter: 'Quarter 2' };
-        const hours = { header: 'Hours', quarter: totalExpectedHoursQuarter2.toFixed(1) + 'h' };
-        for (i = 0; i < expectedHoursQuarter2.length; i++) {
-          ids['class-' + i] = expectedHoursQuarter2[i].id;
-          hours['class-' + i] = expectedHoursQuarter2[i].hours.toFixed(1) + 'h';
-        }
-        for (i = expectedHoursQuarter2.length; i < maxNumberOfClasses; i++) {
-          ids['class-' + i] = '';
-          hours['class-' + i] = '';
-        }
-        table.push(ids);
-        table.push(hours);
-      }
 
       return {
         totalUnits,
@@ -431,9 +367,7 @@ export default {
         expectedHoursQuarter1,
         expectedHoursQuarter2,
         totalExpectedHoursQuarter1,
-        totalExpectedHoursQuarter2,
-        headers,
-        table
+        totalExpectedHoursQuarter2
       };
     },
     semesterYearName: function () {

--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -28,7 +28,7 @@
             </template>
             <div>
               <table v-if="semesterSubjects.length" border="1">
-                <tr>
+                <tr v-if="semesterInformation.expectedHoursQuarter1.length">
                   <th v-if="semesterInformation.anyClassInSingleQuarter" rowspan="2">
                     Quarter 1 <br>
                     <span style="font-weight:normal">{{ semesterInformation.totalExpectedHoursQuarter1.toFixed(1) }}h </span>
@@ -38,13 +38,13 @@
                     {{ subj.id }}
                   </td>
                 </tr>
-                <tr>
+                <tr v-if="semesterInformation.expectedHoursQuarter1.length">
                   <th>Hours</th>
                   <td v-for="subj in semesterInformation.expectedHoursQuarter1" :key="subj.id">
                     {{ subj.hours.toFixed(1) }}h
                   </td>
                 </tr>
-                <tr v-if="semesterInformation.anyClassInSingleQuarter">
+                <tr v-if="semesterInformation.anyClassInSingleQuarter && semesterInformation.expectedHoursQuarter2.length">
                   <th rowspan="2">
                     Quarter 2 <br>
                     <span style="font-weight:normal">{{ semesterInformation.totalExpectedHoursQuarter2.toFixed(1) }}h </span>
@@ -54,7 +54,7 @@
                     {{ subj.id }}
                   </td>
                 </tr>
-                <tr v-if="semesterInformation.anyClassInSingleQuarter">
+                <tr v-if="semesterInformation.anyClassInSingleQuarter && semesterInformation.expectedHoursQuarter2.length">
                   <th>Hours</th>
                   <td v-for="subj in semesterInformation.expectedHoursQuarter2" :key="subj.id">
                     {{ subj.hours.toFixed(1) }}h

--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -38,12 +38,12 @@
               >
                 <template slot="items" slot-scope="props">
                   <tr>
-                    <td v-for="property in semesterInformation.headers">
-                      <span v-if = "property.value === 'quarter'">
+                    <td v-for="property in semesterInformation.headers" :key="property">
+                      <span v-if="property.value === 'quarter'">
                         <b>{{ props.item[property.value] }}</b>
                       </span>
                       <span v-else>
-                        {{ props.item[property.value]}}
+                        {{ props.item[property.value] }}
                       </span>
                     </td>
                   </tr>
@@ -385,7 +385,7 @@ export default {
       const anyClassInSingleQuarter = classesInfo.some((s) => s.quarter_information !== undefined);
       const maxNumberOfClasses = Math.max(expectedHoursQuarter1.length, expectedHoursQuarter2.length);
 
-      let headers = [];
+      const headers = [];
       if (anyClassInSingleQuarter) {
         headers.push({ text: 'Quarter', value: 'quarter' });
       }
@@ -394,31 +394,31 @@ export default {
         headers.push({ text: 'Class ' + i, value: 'class-' + i });
       }
 
-      let table = [];
+      const table = [];
       if (expectedHoursQuarter1.length) {
-        let ids = { header: 'Class', quarter: 'Quarter 1' };
-        let hours = { header: 'Hours', quarter: totalExpectedHoursQuarter1.toFixed(1) + 'h' };
-        for (var i = 0; i < expectedHoursQuarter1.length; i++) {
-          ids['class-'+i] = expectedHoursQuarter1[i].id;
-          hours['class-'+i] = expectedHoursQuarter1[i].hours.toFixed(1) + 'h';
+        const ids = { header: 'Class', quarter: 'Quarter 1' };
+        const hours = { header: 'Hours', quarter: totalExpectedHoursQuarter1.toFixed(1) + 'h' };
+        for (i = 0; i < expectedHoursQuarter1.length; i++) {
+          ids['class-' + i] = expectedHoursQuarter1[i].id;
+          hours['class-' + i] = expectedHoursQuarter1[i].hours.toFixed(1) + 'h';
         }
-        for (var i = expectedHoursQuarter1.length; i < maxNumberOfClasses; i++) {
-          ids['class-'+i] = '';
-          hours['class-i'+i] = '';
+        for (i = expectedHoursQuarter1.length; i < maxNumberOfClasses; i++) {
+          ids['class-' + i] = '';
+          hours['class-i' + i] = '';
         }
         table.push(ids);
         table.push(hours);
       }
       if (expectedHoursQuarter2.length && anyClassInSingleQuarter) {
-        let ids = { header: 'Class', quarter: 'Quarter 2' };
-        let hours = { header: 'Hours', quarter: totalExpectedHoursQuarter2.toFixed(1) + 'h' };
-        for (var i = 0; i < expectedHoursQuarter2.length; i++) {
-          ids['class-'+i] = expectedHoursQuarter2[i].id;
-          hours['class-'+i] = expectedHoursQuarter2[i].hours.toFixed(1) + 'h';
+        const ids = { header: 'Class', quarter: 'Quarter 2' };
+        const hours = { header: 'Hours', quarter: totalExpectedHoursQuarter2.toFixed(1) + 'h' };
+        for (i = 0; i < expectedHoursQuarter2.length; i++) {
+          ids['class-' + i] = expectedHoursQuarter2[i].id;
+          hours['class-' + i] = expectedHoursQuarter2[i].hours.toFixed(1) + 'h';
         }
-        for (var i = expectedHoursQuarter2.length; i < maxNumberOfClasses; i++) {
-          ids['class-'+i] = '';
-          hours['class-'+i] = '';
+        for (i = expectedHoursQuarter2.length; i < maxNumberOfClasses; i++) {
+          ids['class-' + i] = '';
+          hours['class-' + i] = '';
         }
         table.push(ids);
         table.push(hours);

--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -22,7 +22,48 @@
           <span style="min-width: 4.5em; display: inline-block;">
             Units: {{ semesterInformation.totalUnits }}
           </span>
-          Hours: {{ semesterInformation.expectedHours.toFixed(1) }}
+          <v-tooltip bottom>
+            <template v-slot:activator="{ on }">
+              <span v-on="on">Hours: {{ semesterInformation.totalExpectedHours.toFixed(1) }}</span>
+            </template>
+            <div>
+              <table v-if="semesterSubjects.length" border="1">
+                <tr>
+                  <th v-if="semesterInformation.anyClassInSingleQuarter" rowspan="2">
+                    Quarter 1 <br>
+                    <span style="font-weight:normal">{{ semesterInformation.totalExpectedHoursQuarter1.toFixed(1) }}h </span>
+                  </th>
+                  <th>Class</th>
+                  <td v-for="subj in semesterInformation.expectedHoursQuarter1" :key="subj.id">
+                    {{ subj.id }}
+                  </td>
+                </tr>
+                <tr>
+                  <th>Hours</th>
+                  <td v-for="subj in semesterInformation.expectedHoursQuarter1" :key="subj.id">
+                    {{ subj.hours.toFixed(1) }}h
+                  </td>
+                </tr>
+                <tr v-if="semesterInformation.anyClassInSingleQuarter">
+                  <th rowspan="2">
+                    Quarter 2 <br>
+                    <span style="font-weight:normal">{{ semesterInformation.totalExpectedHoursQuarter2.toFixed(1) }}h </span>
+                  </th>
+                  <th>Class</th>
+                  <td v-for="subj in semesterInformation.expectedHoursQuarter2" :key="subj.id">
+                    {{ subj.id }}
+                  </td>
+                </tr>
+                <tr v-if="semesterInformation.anyClassInSingleQuarter">
+                  <th>Hours</th>
+                  <td v-for="subj in semesterInformation.expectedHoursQuarter2" :key="subj.id">
+                    {{ subj.hours.toFixed(1) }}h
+                  </td>
+                </tr>
+              </table>
+              <span v-else>No Classes</span>
+            </div>
+          </v-tooltip>
         </v-flex>
         <v-layout v-if="!isOpen" row xs6 style="max-width: 50%;">
           <v-flex v-for="(subject,subjindex) in semesterSubjects" :key="subject.id+'-'+subjindex+'-'+index" xs3>
@@ -297,21 +338,35 @@ export default {
         tu = isNaN(tu) ? 0 : tu;
         return units + tu;
       }, 0);
-      const totalExpectedHours = function (hours, subj) {
-        let eh = subj.in_class_hours + subj.out_of_class_hours;
-        eh = isNaN(eh) ? subj.total_units : eh;
-        eh = isNaN(eh) ? 0 : eh;
-        return hours + eh;
+      const expectedHours = function (subj) {
+        let hours = subj.in_class_hours + subj.out_of_class_hours;
+        hours = isNaN(hours) ? subj.total_units : hours;
+        hours = isNaN(hours) ? 0 : hours;
+        return {
+          hours: hours,
+          id: subj.subject_id
+        };
+      };
+      const sumExpectedHours = function (hours, subj) {
+        return hours + subj.hours;
       };
       const isInQuarter = function (subj, quarter) {
         return subj.quarter_information === undefined || parseInt(subj.quarter_information.split(',')[0]) === quarter;
       };
-      const expectedHoursQuarter1 = classesInfo.filter((s) => isInQuarter(s, 0)).reduce(totalExpectedHours, 0);
-      const expectedHoursQuarter2 = classesInfo.filter((s) => isInQuarter(s, 1)).reduce(totalExpectedHours, 0);
-      const expectedHours = Math.max(expectedHoursQuarter1, expectedHoursQuarter2);
+      const expectedHoursQuarter1 = classesInfo.filter((s) => isInQuarter(s, 0)).map(expectedHours);
+      const totalExpectedHoursQuarter1 = expectedHoursQuarter1.reduce(sumExpectedHours, 0);
+      const expectedHoursQuarter2 = classesInfo.filter((s) => isInQuarter(s, 1)).map(expectedHours);
+      const totalExpectedHoursQuarter2 = expectedHoursQuarter2.reduce(sumExpectedHours, 0);
+      const totalExpectedHours = Math.max(totalExpectedHoursQuarter1, totalExpectedHoursQuarter2);
+      const anyClassInSingleQuarter = classesInfo.some((s) => s.quarter_information !== undefined);
       return {
-        totalUnits: totalUnits,
-        expectedHours: expectedHours
+        totalUnits,
+        totalExpectedHours,
+        anyClassInSingleQuarter,
+        expectedHoursQuarter1,
+        expectedHoursQuarter2,
+        totalExpectedHoursQuarter1,
+        totalExpectedHoursQuarter2
       };
     },
     semesterYearName: function () {


### PR DESCRIPTION
Closes #224 

Shows a tooltip table that breaks down expected hours by quarter and subject.  Useful to see how hard each quarter will be, and also to see where large amounts of hours come from in your schedule.

![image](https://user-images.githubusercontent.com/33201801/74094283-d2d18c00-4aac-11ea-8eb5-333eabd4b665.png)
