### PR TITLE
Remove unnecessary Vue.sets

### DIFF
--- a/src/stores/courseData.js
+++ b/src/stores/courseData.js
@@ -53,7 +53,7 @@ const store = new Vuex.Store({
   mutations: {
     addClass (state, newClass) {
       state.roads[state.activeRoad].contents.selectedSubjects[newClass.semester].push(newClass);
-      Vue.set(state.roads[state.activeRoad], 'changed', moment().format(DATE_FORMAT));
+      state.roads[state.activeRoad].changed = moment().format(DATE_FORMAT);
     },
     addFromCard (state, classItem) {
       state.addingFromCard = true;
@@ -62,7 +62,6 @@ const store = new Vuex.Store({
     addReq (state, event) {
       state.roads[state.activeRoad].contents.coursesOfStudy.push(event);
       state.roads[state.activeRoad].changed = moment().format(DATE_FORMAT);
-      Vue.set(state.roads, state.activeRoad, state.roads[state.activeRoad]);
       state.fulfillmentNeeded = event;
     },
     allowCookies (state) {
@@ -98,11 +97,11 @@ const store = new Vuex.Store({
       state.roads[state.activeRoad].contents.selectedSubjects[currentClass.semester].splice(classIndex, 1);
       currentClass.semester = semester;
       state.roads[state.activeRoad].contents.selectedSubjects[semester].push(currentClass);
-      Vue.set(state.roads[state.activeRoad], 'changed', moment().format(DATE_FORMAT));
+      state.roads[state.activeRoad].changed = moment().format(DATE_FORMAT);
     },
     overrideWarnings (state, payload) {
       const classIndex = state.roads[state.activeRoad].contents.selectedSubjects[payload.classInfo.semester].indexOf(payload.classInfo);
-      Vue.set(state.roads[state.activeRoad].contents.selectedSubjects[payload.classInfo.semester][classIndex], 'overrideWarnings', payload.override);
+      state.roads[state.activeRoad].contents.selectedSubjects[payload.classInfo.semester][classIndex].overrideWarnings = payload.override;
     },
     setUnretrieved (state, roadIDs) {
       state.unretrieved = roadIDs;
@@ -200,12 +199,12 @@ const store = new Vuex.Store({
     },
     removeClass (state, { classInfo, classIndex }) {
       state.roads[state.activeRoad].contents.selectedSubjects[classInfo.semester].splice(classIndex, 1);
-      Vue.set(state.roads[state.activeRoad], 'changed', moment().format(DATE_FORMAT));
+      state.roads[state.activeRoad].changed = moment().format(DATE_FORMAT);
     },
     removeReq (state, event) {
       const reqIndex = state.roads[state.activeRoad].contents.coursesOfStudy.indexOf(event);
       state.roads[state.activeRoad].contents.coursesOfStudy.splice(reqIndex, 1);
-      Vue.set(state.roads[state.activeRoad], 'changed', moment().format(DATE_FORMAT));
+      state.roads[state.activeRoad].changed = moment().format(DATE_FORMAT);
       state.fulfillmentNeeded = 'none';
     },
     resetID (state, { oldid, newid }) {
@@ -249,8 +248,8 @@ const store = new Vuex.Store({
       state.roads = roads;
     },
     setRoadName (state, { id, name }) {
-      Vue.set(state.roads[id], 'name', name);
-      Vue.set(state.roads[id], 'changed', moment().format(DATE_FORMAT));
+      state.roads[id].name = name;
+      state.roads[id].changed = moment().format(DATE_FORMAT);
     },
     setSubjectsInfo (state, data) {
       state.subjectsInfo = data;
@@ -260,7 +259,7 @@ const store = new Vuex.Store({
     },
     updateProgress (state, progress) {
       Vue.set(state.roads[state.activeRoad].contents.progressOverrides, progress.listID, progress.progress);
-      Vue.set(state.roads[state.activeRoad], 'changed', moment().format(DATE_FORMAT));
+      state.roads[state.activeRoad].changed = moment().format(DATE_FORMAT);
     },
     setFromLocalStorage (state, localStore) {
       store.replaceState(localStore);


### PR DESCRIPTION
Keep only the Vue.sets that are needed, i.e. those which cause property addition that Vue cannot detect.

Closes #265 