### PR TITLE
Renumber local roads before attempting to send to server

### DIFF
--- a/src/components/Auth.vue
+++ b/src/components/Auth.vue
@@ -290,7 +290,7 @@ export default {
             this.saveRemote(this.newRoads[i]);
           }
           const fileKeys = Object.keys(files);
-          for (var i = 0; i < fileKeys.length; i++) {
+          for (i = 0; i < fileKeys.length; i++) {
             const blankRoad = {
               downloaded: moment().format(DATE_FORMAT),
               changed: files[fileKeys[i]].changed,

--- a/src/components/Auth.vue
+++ b/src/components/Auth.vue
@@ -277,9 +277,6 @@ export default {
     },
     getUserData: function () {
       this.gettingUserData = true;
-      for (var i = 0; i < this.newRoads.length; i++) {
-        this.saveRemote(this.newRoads[i]);
-      }
       this.getSecure('/sync/roads/')
         .then(function (response) {
           if (response.status === 200 && response.data.success) {
@@ -289,6 +286,9 @@ export default {
           }
         }).then(function (files) {
           this.renumberRoads(files);
+          for (var i = 0; i < this.newRoads.length; i++) {
+            this.saveRemote(this.newRoads[i]);
+          }
           const fileKeys = Object.keys(files);
           for (var i = 0; i < fileKeys.length; i++) {
             const blankRoad = {


### PR DESCRIPTION
Fixes #321 

Makes sure that roads are renumbered and there are no duplicates BEFORE saving local roads to fireroad server.