### PR TITLE
Convert names to lowercase on Road import

### DIFF
--- a/src/components/ImportExport.vue
+++ b/src/components/ImportExport.vue
@@ -231,7 +231,7 @@ export default {
     },
     otherRoadHasName: function (roadName) {
       const otherRoadNames = Object.keys(this.roads).filter(function (road) {
-        return this.roads[road].name === roadName;
+        return this.roads[road].name.toLowerCase() === roadName.toLowerCase();
       }.bind(this));
       return otherRoadNames.length > 0;
     }


### PR DESCRIPTION
This PR converts `Road` names to lowercase when verifying that the name of a `Road` in the `ImportExport` dialog doesn't conflict.

Previously, this check was ignoring case, resulting in conflicting `Roads` being creating and causing conflicts between the two `Roads`.