### PR TITLE
Add meta tag to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <meta name="description" content="CourseRoad is a tool for planning out your classes over your entire time at MIT.
+      It makes it easy to explore different majors and minors, view your progress towards their requirements, and
+      choose which classes to take when in order to maximize your time at MIT.">
     <!-- <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Roboto" /> -->
     <title>CourseRoad</title>
   </head>


### PR DESCRIPTION
This PR adds a working `<meta>` tag to `index.html` that will display a proper description in `Google`. This description is longer and contains more important keywords (namely the word `CourseRoad`) than the previous one, allowing `Google` to use this instead of attempting to generate its own description from the mobile site text.

This PR fixes #311.