### PR TITLE
Make it clear audit classes can be dragged and clicked

### DIFF
--- a/src/components/Audit.vue
+++ b/src/components/Audit.vue
@@ -31,7 +31,7 @@
           <div
             slot-scope="{ hover }"
             :class="{ 'elevation-3 grey lighten-3': hover }"
-            :style="(leaf && canDrag(item) ? 'cursor: grab' : 'cursor:pointer')"
+            :style="(leaf && canDrag(item) ? 'cursor: grab' : 'cursor: pointer')"
           >
             <v-icon
               v-if="!('reqs' in item)"
@@ -148,10 +148,10 @@ import Requirement from './Requirement.vue';
 import classInfoMixin from './../mixins/classInfo.js';
 export default {
   name: 'Audit',
-  mixins: [classInfoMixin],
   components: {
     requirement: Requirement
   },
+  mixins: [classInfoMixin],
   props: {
     selectedReqs: {
       type: Array,
@@ -330,8 +330,8 @@ export default {
 
 <style scoped>
 .appendLeft {
-  float:left;
-  position:relative;
+  float: left;
+  position: relative;
   bottom: 3px;
 }
 .percentage-bar {

--- a/src/components/Audit.vue
+++ b/src/components/Audit.vue
@@ -40,25 +40,18 @@
         </v-icon>
       </template>
       <template slot="label" slot-scope="{ item, leaf}">
-        <v-hover v-if="leaf">
+        <v-hover :disabled="!leaf">
           <requirement
             slot-scope="{ hover }"
-            :class="{ 'elevation-3': hover }"
+            :class="{ 'elevation-3 grey lighten-3': hover }"
+            :style="(leaf ? 'cursor: grab' : 'cursor:pointer')"
             draggable="true"
-            style="cursor: grab; margin: 4px;"
             :req="item"
             :is-leaf="leaf"
             @click.native="clickRequirement(item)"
             @click-info="reqInfo($event, item)"
           />
         </v-hover>
-        <requirement
-          v-else
-          :req="item"
-          :is-leaf="leaf"
-          @click.native="clickRequirement(item)"
-          @click-info="reqInfo($event, item)"
-        />
       </template>
     </v-treeview>
 

--- a/src/components/Audit.vue
+++ b/src/components/Audit.vue
@@ -26,30 +26,32 @@
       open-on-click
       :activatable="false"
     >
-      <template slot="prepend" slot-scope="{ item }">
-        <v-icon
-          v-if="!('reqs' in item)"
-          :style="fulfilledIcon(item)"
-          @click="clickRequirement(item)"
-        >
-          {{ item['plain-string'] ?
-            (item["list-id"] in progressOverrides ?
-              (item.fulfilled ? "assignment_turned_in" : "assignment") :
-              "assignment_late" ) :
-            item.fulfilled ? "done" : "remove" }}
-        </v-icon>
-      </template>
       <template slot="label" slot-scope="{ item, leaf}">
         <v-hover :disabled="!leaf">
-          <requirement
+          <div
             slot-scope="{ hover }"
             :class="{ 'elevation-3 grey lighten-3': hover }"
             :style="(leaf ? 'cursor: grab' : 'cursor:pointer')"
-            :req="item"
-            :is-leaf="leaf"
-            @click.native="clickRequirement(item)"
-            @click-info="reqInfo($event, item)"
-          />
+          >
+            <v-icon
+              v-if="!('reqs' in item)"
+              class="appendLeft"
+              :style="fulfilledIcon(item)"
+              @click="clickRequirement(item)"
+            >
+              {{ item['plain-string'] ?
+                (item["list-id"] in progressOverrides ?
+                  (item.fulfilled ? "assignment_turned_in" : "assignment") :
+                  "assignment_late" ) :
+                item.fulfilled ? "done" : "remove" }}
+            </v-icon>
+            <requirement
+              :req="item"
+              :is-leaf="leaf"
+              @click.native="clickRequirement(item)"
+              @click-info="reqInfo($event, item)"
+            />
+          </div>
         </v-hover>
       </template>
     </v-treeview>
@@ -325,6 +327,9 @@ export default {
 </script>
 
 <style scoped>
+.appendLeft {
+  float:left;
+}
 .percentage-bar {
   background: linear-gradient(
     90deg,

--- a/src/components/Audit.vue
+++ b/src/components/Audit.vue
@@ -329,6 +329,8 @@ export default {
 <style scoped>
 .appendLeft {
   float:left;
+  position:relative;
+  bottom: 3px;
 }
 .percentage-bar {
   background: linear-gradient(

--- a/src/components/Audit.vue
+++ b/src/components/Audit.vue
@@ -40,7 +40,20 @@
         </v-icon>
       </template>
       <template slot="label" slot-scope="{ item, leaf}">
+        <v-hover v-if="leaf">
+          <requirement
+            slot-scope="{ hover }"
+            :class="{ 'elevation-3': hover }"
+            draggable="true"
+            style="cursor: grab; margin: 4px;"
+            :req="item"
+            :is-leaf="leaf"
+            @click.native="clickRequirement(item)"
+            @click-info="reqInfo($event, item)"
+          />
+        </v-hover>
         <requirement
+          v-else
           :req="item"
           :is-leaf="leaf"
           @click.native="clickRequirement(item)"

--- a/src/components/Audit.vue
+++ b/src/components/Audit.vue
@@ -45,7 +45,6 @@
             slot-scope="{ hover }"
             :class="{ 'elevation-3 grey lighten-3': hover }"
             :style="(leaf ? 'cursor: grab' : 'cursor:pointer')"
-            draggable="true"
             :req="item"
             :is-leaf="leaf"
             @click.native="clickRequirement(item)"

--- a/src/components/Audit.vue
+++ b/src/components/Audit.vue
@@ -27,11 +27,11 @@
       :activatable="false"
     >
       <template slot="label" slot-scope="{ item, leaf}">
-        <v-hover :disabled="!leaf">
+        <v-hover :disabled="!leaf || !canDrag(item)">
           <div
             slot-scope="{ hover }"
             :class="{ 'elevation-3 grey lighten-3': hover }"
-            :style="(leaf ? 'cursor: grab' : 'cursor:pointer')"
+            :style="(leaf && canDrag(item) ? 'cursor: grab' : 'cursor:pointer')"
           >
             <v-icon
               v-if="!('reqs' in item)"
@@ -145,8 +145,10 @@
 
 <script>
 import Requirement from './Requirement.vue';
+import classInfoMixin from './../mixins/classInfo.js';
 export default {
   name: 'Audit',
+  mixins: [classInfoMixin],
   components: {
     requirement: Requirement
   },

--- a/src/components/Requirement.vue
+++ b/src/components/Requirement.vue
@@ -20,15 +20,7 @@
           <span style="font-style:italic">{{ req['threshold-desc'] }}</span>
         </div>
         <span v-else>
-          <v-hover>
-            <span
-              v-if="'title' in req"
-              slot-scope="{ hover }"
-              :class="{ 'elevation-3': hover }"
-              style="cursor: grab">
-              {{ req.title }}
-            </span>
-          </v-hover>
+          <span v-if="'title' in req"> {{ req.title }} </span>
         </span>
         <span v-if="!req['plain-string']">
           <span v-if="!('title' in req) && 'req' in req">

--- a/src/components/Requirement.vue
+++ b/src/components/Requirement.vue
@@ -20,7 +20,15 @@
           <span style="font-style:italic">{{ req['threshold-desc'] }}</span>
         </div>
         <span v-else>
-          <span v-if="'title' in req">{{ req.title }}</span>
+          <v-hover>
+            <span
+              v-if="'title' in req"
+              slot-scope="{ hover }"
+              :class="{ 'elevation-3': hover }"
+              style="cursor: grab">
+              {{ req.title }}
+            </span>
+          </v-hover>
         </span>
         <span v-if="!req['plain-string']">
           <span v-if="!('title' in req) && 'req' in req">

--- a/src/components/Requirement.vue
+++ b/src/components/Requirement.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="requirement"
-    :draggable="canDrag"
+    :draggable="canDrag(req)"
     @dragstart="dragStart"
     @mouseover="hoveringOver = true"
     @mouseleave="hoveringOver = false"
@@ -64,8 +64,11 @@
 </template>
 
 <script>
+import classInfoMixin from './../mixins/classInfo.js';
+
 export default {
   name: 'Requirement',
+  mixins: [classInfoMixin],
   props: {
     req: {
       type: Object,
@@ -84,27 +87,8 @@ export default {
     };
   },
   computed: {
-    classInfo: function () {
-      if ('req' in this.req) {
-        if (this.req.req in this.$store.state.subjectsIndex) {
-          return this.$store.state.subjectsInfo[this.$store.state.subjectsIndex[this.req.req]];
-        }
-        let attributeReq = this.req.req;
-        if (attributeReq.indexOf('GIR:') === 0) {
-          attributeReq = attributeReq.substring(4);
-        }
-        if (attributeReq in this.$store.state.genericIndex) {
-          return this.$store.state.genericCourses[this.$store.state.genericIndex[attributeReq]];
-        }
-      }
-      return undefined;
-    },
     iconColor: function () {
       return this.iconHover ? 'info' : 'grey';
-    },
-    canDrag: function () {
-      return this.classInfo !== undefined ||
-        ('req' in this.req && (Object.keys(this.$store.state.subjectsIndex).length === 0));
     },
     reqFulfilled: function () {
       return {

--- a/src/components/Requirement.vue
+++ b/src/components/Requirement.vue
@@ -119,7 +119,7 @@ export default {
   },
   methods: {
     dragStart: function (event) {
-      let usedInfo = this.classInfo;
+      let usedInfo = this.classInfo(this.req);
       if (usedInfo === undefined) {
         usedInfo = { id: this.req.req };
       }

--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -8,12 +8,13 @@
     <v-container slot="header" grid-list-xs style="padding: 0px; margin-left: 0px;">
       <v-layout row align-center style="user-select: none;">
         <v-flex xs6>
-          <span style="width: 6em; display: inline-block;">
+          <span style="width: 12em; display: inline-block;">
             <b>
               <v-hover>
                 <span slot-scope="{ hover }" :class="hover && 'hovering'" @click="openChangeYearDialog">
+                  {{ semesterName }}
                   {{ semesterType }}
-                  {{ semesterYear }}
+                  <span v-if="index>0">{{ "'" + semesterYear.toString().substring(2) }}</span>
                 </span>
               </v-hover>
             </b>
@@ -312,6 +313,15 @@ export default {
         totalUnits: totalUnits,
         expectedHours: expectedHours
       };
+    },
+    semesterName: function () {
+      const yearNames = ['Freshman', 'Sophomore', 'Junior', 'Senior', 'Fifth Year'];
+      if (this.index === 0) {
+        return '';
+      } else {
+        const yearIndex = Math.floor((this.index - 1) / 3);
+        return yearNames[yearIndex];
+      }
     },
     semesterYear: function () {
       return this.index === 0

--- a/src/mixins/classInfo.js
+++ b/src/mixins/classInfo.js
@@ -1,0 +1,24 @@
+export default {
+  methods: {
+    classInfo: function (req) {
+      if ('req' in req) {
+        if (req.req in this.$store.state.subjectsIndex) {
+          return this.$store.state.subjectsInfo[this.$store.state.subjectsIndex[req.req]];
+        }
+        let attributeReq = req.req;
+        if (attributeReq.indexOf('GIR:') === 0) {
+          attributeReq = attributeReq.substring(4);
+        }
+        if (attributeReq in this.$store.state.genericIndex) {
+          return this.$store.state.genericCourses[this.$store.state.genericIndex[attributeReq]];
+        }
+      }
+      return undefined;
+    },
+    canDrag: function (req) {
+      return this.classInfo(req) !== undefined ||
+              ('req' in req && (Object.keys(this.$store.state.subjectsIndex).length === 0));
+    }
+  }
+
+};


### PR DESCRIPTION
Closes #127 
The audit reqs that can be dragged now elevate when hovered over by the mouse. The mouse cursor also changes to a grabby hand.

ClassInfo and canDrag have been moved from Requirement into a mixin called classInfo so that they can be used by the v-hover in the audit. They have also changed from computed to methods to allow a req to be passed into them. As such, the usages of classInfo and canDrag within Requirement now pass the req prop as a parameter.

The icon next to the requirement on the leaf level of the tree is no longer its own template but rather within the label slot. This was so the hover encompasses both the icon and text which makes it much more apparent. Some css styling was added so that the icon would be on the left side and be centered with the text of the label.