### PR TITLE
Make override warnings visual effect immediate

### DIFF
--- a/src/components/Class.vue
+++ b/src/components/Class.vue
@@ -57,13 +57,14 @@
           <!-- eslint-disable-next-line vue/no-v-html -->
           <p v-for="warning in warnings" :key="warning" v-html="warning" />
           <v-switch
+            @change="$store.commit('overrideWarnings', {override:shouldOverrideWarnings,classInfo:classInfo})"
             v-model="shouldOverrideWarnings"
             label="Override warnings"
             color="orange darken-3"
           />
         </v-card-text>
         <v-card-actions style="justify-content: flex-end;">
-          <v-btn flat @click="warningDialog = false; $store.commit('overrideWarnings', {override:shouldOverrideWarnings,classInfo:classInfo})">
+          <v-btn flat @click="warningDialog = false">
             Close
           </v-btn>
         </v-card-actions>


### PR DESCRIPTION
Previously, override warning effects only take place when you click a
specific button. This allows the visual effect to happen immediately at
the toggle.

resolves #402 