### PR TITLE
Add validation for visible list prop

### DIFF
--- a/src/components/Road.vue
+++ b/src/components/Road.vue
@@ -117,7 +117,9 @@ export default {
   mounted () {
     const visibleList = JSON.parse(this.$cookies.get('visibleList' + this.roadID));
     if (this.$store.state.cookiesAllowed && visibleList) {
-      this.visibleList = visibleList;
+      if (Array.isArray(visibleList) && visibleList.length == this.numSems) {
+        this.visibleList = visibleList;
+      }
     };
   }
 };

--- a/src/components/Road.vue
+++ b/src/components/Road.vue
@@ -119,6 +119,8 @@ export default {
     if (this.$store.state.cookiesAllowed && visibleList) {
       if (Array.isArray(visibleList) && visibleList.length == this.numSems) {
         this.visibleList = visibleList;
+      } else {
+        this.$cookies.remove('visibleList' + this.roadID);
       }
     };
   }


### PR DESCRIPTION
Closes #427 

If cookies for visible list become incorrect (e.g. if we add in the future changing # of semesters, for example), this will not load them and remove them from cookies.  Once the open state is changed from default new cookies will be written.