### PR TITLE
Fix url redirecting to default road id when it shouldn't

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ tests/e2e/videos
 tests/e2e/downloads
 
 env.sh
+
+# VSCode Debugging Configurations
+.vscode

--- a/src/components/Auth.vue
+++ b/src/components/Auth.vue
@@ -346,7 +346,9 @@ export default {
           if (fileKeys.includes(this.$route.params.road)) {
             this.$store.commit('setActiveRoad', this.$route.params.road);
           } else {
+            // Redirect to first road if road cannot be found
             this.$store.commit('setActiveRoad', Object.keys(this.roads)[0]);
+            this.$router.push({ path: `/road/${Object.keys(this.roads)[0]}` });
           }
           // Set list of unretrieved roads to all but first road ID
           this.$store.commit('setUnretrieved', fileKeys);

--- a/src/components/Auth.vue
+++ b/src/components/Auth.vue
@@ -343,11 +343,20 @@ export default {
           if (this.justLoaded && fileKeys.length > 0) {
             this.$store.commit('deleteRoad', '$defaultroad$');
           }
-          this.$store.commit('setActiveRoad', Object.keys(this.roads)[0]);
+          if (fileKeys.includes(this.$route.params.road)) {
+            this.$store.commit('setActiveRoad', this.$route.params.road);
+          } else {
+            this.$store.commit('setActiveRoad', Object.keys(this.roads)[0]);
+          }
           // Set list of unretrieved roads to all but first road ID
           this.$store.commit('setUnretrieved', fileKeys);
           if (fileKeys.length) {
-            return this.retrieveRoad(fileKeys[0]);
+            // Retrieves based on url and defaults to first road if unable to find it
+            if (fileKeys.includes(this.$route.params.road)) {
+              return this.retrieveRoad(this.$route.params.road);
+            } else {
+              return this.retrieveRoad(fileKeys[0]);
+            }
           }
         }.bind(this)).then(function () {
           this.gettingUserData = false;

--- a/src/pages/MainPage.vue
+++ b/src/pages/MainPage.vue
@@ -287,7 +287,6 @@ export default {
   watch: {
     // call fireroad to check fulfillment if you change active roads or change something about a road
     activeRoad: function (newRoad) {
-      this.justLoaded = false;
       if (this.$store.state.unretrieved.indexOf(newRoad) >= 0 && !this.$refs.authcomponent.gettingUserData) {
         const _this = this;
         this.$refs.authcomponent.retrieveRoad(newRoad).then(function () {
@@ -296,9 +295,12 @@ export default {
       } else if (newRoad !== '') {
         this.updateFulfillment(this.$store.state.fulfillmentNeeded);
       }
-      if (newRoad !== '') {
+      // If just loaded, store isn't loaded yet
+      // and so we can't overwrite the router just yet
+      if (newRoad !== '' && !this.justLoaded) {
         this.$router.push({ path: `/road/${newRoad}` });
       }
+      this.justLoaded = false;
     },
     cookiesAllowed: function (newCA) {
       if (newCA) {
@@ -325,6 +327,9 @@ export default {
       deep: true
     },
     $route () {
+      this.setActiveRoad();
+    },
+    justLoaded () {
       this.setActiveRoad();
     }
   },
@@ -429,7 +434,6 @@ export default {
           return true;
         }
       }
-      this.$router.push({ path: `/road/${this.activeRoad}` });
       return false;
     },
     addRoad: function (roadName, cos = ['girs'], ss = Array.from(Array(16), () => []), overrides = {}) {

--- a/src/pages/MainPage.vue
+++ b/src/pages/MainPage.vue
@@ -431,6 +431,9 @@ export default {
       if (this.roads.hasOwnProperty(this.$route.params.road)) {
         this.$store.commit('setActiveRoad', roadRequested);
         return true;
+      } else if (!this.$cookies.isKey('accessInfo')) {
+        // If user isn't logged in, and bad road id in url, then redirect to default road
+        this.$router.push({ path: '/' });
       }
       return false;
     },

--- a/src/pages/MainPage.vue
+++ b/src/pages/MainPage.vue
@@ -427,12 +427,12 @@ export default {
       }
     },
     setActiveRoad: function () {
+      const roadRequested = this.$route.params.road;
       if (this.roads.hasOwnProperty(this.$route.params.road)) {
-        const roadRequested = this.$route.params.road;
-        if (roadRequested in this.roads) {
-          this.$store.commit('setActiveRoad', roadRequested);
-          return true;
-        }
+        this.$store.commit('setActiveRoad', roadRequested);
+        return true;
+      } else if (!this.justLoaded && this.$store.state.loggedIn !== undefined && !this.$store.state.loggedIn) {
+        this.$router.push({ path: '/' });
       }
       return false;
     },

--- a/src/pages/MainPage.vue
+++ b/src/pages/MainPage.vue
@@ -431,8 +431,6 @@ export default {
       if (this.roads.hasOwnProperty(this.$route.params.road)) {
         this.$store.commit('setActiveRoad', roadRequested);
         return true;
-      } else if (!this.justLoaded && this.$store.state.loggedIn !== undefined && !this.$store.state.loggedIn) {
-        this.$router.push({ path: '/' });
       }
       return false;
     },

--- a/src/pages/MainPage.vue
+++ b/src/pages/MainPage.vue
@@ -325,12 +325,6 @@ export default {
         }
       },
       deep: true
-    },
-    $route () {
-      this.setActiveRoad();
-    },
-    justLoaded () {
-      this.setActiveRoad();
     }
   },
   created () {
@@ -434,11 +428,7 @@ export default {
       } else if (!this.$cookies.isKey('accessInfo')) {
         // If user isn't logged in, and bad road id in url, then redirect to default road
         const defaultRoadId = this.$store.state.activeRoad;
-        if (defaultRoadId !== undefined) {
-          this.$router.push({ path: `/road/${defaultRoadId}` });
-        } else {
-          this.$router.push({ path: '/' });
-        }
+        this.$router.replace({ path: `/road/${defaultRoadId}` });
       }
       return false;
     },

--- a/src/pages/MainPage.vue
+++ b/src/pages/MainPage.vue
@@ -433,7 +433,12 @@ export default {
         return true;
       } else if (!this.$cookies.isKey('accessInfo')) {
         // If user isn't logged in, and bad road id in url, then redirect to default road
-        this.$router.push({ path: '/' });
+        const defaultRoadId = this.$store.state.activeRoad;
+        if (defaultRoadId !== undefined) {
+          this.$router.push({ path: `/road/${defaultRoadId}` });
+        } else {
+          this.$router.push({ path: '/' });
+        }
       }
       return false;
     },

--- a/tests/e2e/specs/audit.js
+++ b/tests/e2e/specs/audit.js
@@ -6,7 +6,7 @@ import reqs from '../assets/list_reqs.js';
 import { objectSlice } from '../support/utilities.js';
 
 describe('Audit Tests', () => {
-  it.only('Adds and removes majors', () => {
+  it('Adds and removes majors', () => {
     cy.route(Cypress.env('VUE_APP_FIREROAD_URL') + '/courses/all?full=true', []);
     cy.route('POST', Cypress.env('VUE_APP_FIREROAD_URL') + '/requirements/progress/girs/', girs);
     cy.route('POST', Cypress.env('VUE_APP_FIREROAD_URL') + '/requirements/progress/major21M-1/', major21M1);

--- a/tests/e2e/specs/road.js
+++ b/tests/e2e/specs/road.js
@@ -478,6 +478,7 @@ describe('Road tests', () => {
         cy.url().should('include', `/road/${roadID}`);
         
         // Ensure 7.46 in Router Road
+        // TODO Error here only exists if logged in, no issue if local storage
         cy.getByDataCy(`road_${roadID}__semester_1`)
           .within(() => {
             cy.getByDataCy('classInSemester1_7_46')
@@ -498,7 +499,12 @@ describe('Road tests', () => {
   it("Handles unknown road ids in url correctly", () => {
     // Two things should occur, the user is redirected to the default road
     // and the url shows the id of the default road instead of the unknown road
-
+    cy.visit('/');
+    const random_id = 909258;
+    cy.visit(`/road/${random_id}`);
+    
+    // TODO Error exists only for a user who is not logged in
+    cy.url().should('include', '/road/$default_road$');
   })
 
 });

--- a/tests/e2e/specs/road.js
+++ b/tests/e2e/specs/road.js
@@ -400,7 +400,7 @@ describe('Road tests', () => {
         expect(road.selectedSubjects[1].id).to.equal('12.001');
       });
   });
-  
+
   it("Loads correct road based on url", () => {
     cy.route(Cypress.env('VUE_APP_FIREROAD_URL') + '/courses/all?full=true',
       [
@@ -458,7 +458,7 @@ describe('Road tests', () => {
       .then(function () {
         cy.getByDataCy('roadTab' + this.roadID)
           .click();
-        
+
         // Add 7.46 to 'Test Road - Router'
         cy.getByDataCy('classSearchInput')
           .type('{backspace}{backspace}{backspace}{backspace}')
@@ -476,7 +476,7 @@ describe('Road tests', () => {
       .then(roadID => {
         cy.visit(`/road/${roadID}`);
         cy.url().should('include', `/road/${roadID}`);
-        
+
         // Ensure 7.46 in Router Road
         // TODO Error here only exists if logged in, no issue if local storage
         cy.getByDataCy(`road_${roadID}__semester_1`)
@@ -485,24 +485,29 @@ describe('Road tests', () => {
               .should('exist');
           });
       })
-    
-      cy.visit('/');
-      // Ensure 3.45 in default road
-      cy.getByDataCy('road_$defaultroad$__semester_1')
-        .within(() => {
-          cy.getByDataCy('classInSemester1_3_45')
-            .should('exist');
-        });
+
+    cy.visit('/');
+    // Ensure 3.45 in default road
+    cy.getByDataCy('road_$defaultroad$__semester_1')
+      .within(() => {
+        cy.getByDataCy('classInSemester1_3_45')
+          .should('exist');
+      });
 
   });
-  
+
   it("Handles unknown road ids in url correctly", () => {
     // Two things should occur, the user is redirected to the default road
     // and the url shows the id of the default road instead of the unknown road
+    const fakeCode = 'abcdefg';
+    const fakeAccessToken = 'jGWHEO2IfpdSEt1dyDkf';
+    cy.setupAuth(fakeCode, fakeAccessToken);
     cy.visit('/');
+    cy.login(fakeCode);
+
     const random_id = 909258;
     cy.visit(`/road/${random_id}`);
-    
+
     // TODO Error exists only for a user who is not logged in
     cy.url().should('include', '/road/$default_road$');
   })

--- a/tests/e2e/specs/road.js
+++ b/tests/e2e/specs/road.js
@@ -3,6 +3,7 @@ import girs from '../assets/reqs_girs.js';
 import major21M1 from '../assets/reqs_21m_1.js';
 import reqs from '../assets/list_reqs.js';
 import { objectSlice } from '../support/utilities.js';
+import { files } from '../assets/sync_roads.js';
 
 const path = require('path');
 
@@ -496,7 +497,7 @@ describe('Road tests', () => {
 
   });
 
-  it("Handles unknown road ids in url correctly", () => {
+  it("Handles unknown road ids in url correctly (Logged In)", () => {
     // Two things should occur, the user is redirected to the default road
     // and the url shows the id of the default road instead of the unknown road
     const fakeCode = 'abcdefg';
@@ -508,8 +509,11 @@ describe('Road tests', () => {
     const random_id = 909258;
     cy.visit(`/road/${random_id}`);
 
+
+    // Should be the road that is defaulted to when no road id is specified
+    const defaultRoadId = Object.keys(files)[0];
     // TODO Error exists only for a user who is not logged in
-    cy.url().should('include', '/road/$default_road$');
+    cy.url().should('include', `/road/${defaultRoadId}`);
   })
 
 });

--- a/tests/e2e/specs/road.js
+++ b/tests/e2e/specs/road.js
@@ -479,11 +479,10 @@ describe('Road tests', () => {
         cy.url().should('include', `/road/${roadID}`);
 
         // Ensure 7.46 in Router Road
-        // TODO Error here only exists if logged in, no issue if local storage
         cy.getByDataCy(`road_${roadID}__semester_1`)
           .within(() => {
             cy.getByDataCy('classInSemester1_7_46')
-              .should('exist');
+              .should('be.visible');
           });
       });
 

--- a/tests/e2e/specs/road.js
+++ b/tests/e2e/specs/road.js
@@ -536,7 +536,7 @@ describe('Road tests', () => {
     const randomId = 909258;
     cy.visit(`/road/${randomId}`);
 
-    cy.url().should('include', '/road/$defaultroad$');
+    cy.url().should('not.include', `/road/${randomId}`);
   });
 
   it('Handles unknown road ids in url correctly (Logged In)', () => {

--- a/tests/e2e/specs/road.js
+++ b/tests/e2e/specs/road.js
@@ -507,6 +507,7 @@ describe('Road tests', () => {
     // Should be file 123, which contains 14.03
     const defaultRoadId = Object.keys(syncedRoads.files)[0];
 
+    // Test whether the site navigates to the correct road based on the url and loads its content
     const testRoad = syncedRoads.file456;
     cy.visit(`/road/${testRoad.id}`);
     cy.url().should('include', `/road/${testRoad.id}`);
@@ -518,6 +519,7 @@ describe('Road tests', () => {
           .should('exist');
       });
 
+    // Test whether default road gets correctly loaded when no road id given
     cy.visit('/');
     // Ensure 14.03 in default road
     cy.getByDataCy(`road_${defaultRoadId}__semester_1`)

--- a/tests/e2e/specs/road.js
+++ b/tests/e2e/specs/road.js
@@ -536,6 +536,7 @@ describe('Road tests', () => {
     cy.visit(`/road/${randomId}`);
 
     cy.url().should('not.include', `/road/${randomId}`);
+    cy.url().should('include', '/road/$defaultroad$');
   });
 
   it('Handles unknown road ids in url correctly (Logged In)', () => {

--- a/tests/e2e/specs/road.js
+++ b/tests/e2e/specs/road.js
@@ -402,7 +402,7 @@ describe('Road tests', () => {
       });
   });
 
-  it("Loads correct road based on url", () => {
+  it("Loads correct road based on url (Logged Out)", () => {
     cy.route(Cypress.env('VUE_APP_FIREROAD_URL') + '/courses/all?full=true',
       [
         {
@@ -497,6 +497,17 @@ describe('Road tests', () => {
 
   });
 
+  it("Handles unknown road ids in url correctly (Logged Out)", () => {
+    // Two things should occur, the user is redirected to the default road
+    // and the url shows the id of the default road instead of the unknown road
+    cy.visit('/');
+
+    const randomId = 909258;
+    cy.visit(`/road/${randomId}`);
+
+    cy.url().should('include', '/road/$defaultroad$');
+  });
+
   it("Handles unknown road ids in url correctly (Logged In)", () => {
     // Two things should occur, the user is redirected to the default road
     // and the url shows the id of the default road instead of the unknown road
@@ -506,14 +517,13 @@ describe('Road tests', () => {
     cy.visit('/');
     cy.login(fakeCode);
 
-    const random_id = 909258;
-    cy.visit(`/road/${random_id}`);
+    const randomId = 909258;
+    cy.visit(`/road/${randomId}`);
 
 
     // Should be the road that is defaulted to when no road id is specified
     const defaultRoadId = Object.keys(files)[0];
-    // TODO Error exists only for a user who is not logged in
     cy.url().should('include', `/road/${defaultRoadId}`);
-  })
+  });
 
 });

--- a/tests/e2e/specs/road.js
+++ b/tests/e2e/specs/road.js
@@ -3,7 +3,7 @@ import girs from '../assets/reqs_girs.js';
 import major21M1 from '../assets/reqs_21m_1.js';
 import reqs from '../assets/list_reqs.js';
 import { objectSlice } from '../support/utilities.js';
-import { files } from '../assets/sync_roads.js';
+import syncedRoads from '../assets/sync_roads.js';
 
 const path = require('path');
 
@@ -497,6 +497,37 @@ describe('Road tests', () => {
 
   });
 
+  it("Loads correct road based on url (Logged In)", () => {
+    const fakeCode = 'abcdefg';
+    const fakeAccessToken = 'jGWHEO2IfpdSEt1dyDkf';
+    cy.setupAuth(fakeCode, fakeAccessToken);
+    cy.visit('/');
+    cy.login(fakeCode);
+
+    // Should be file 123, which contains 14.03
+    const defaultRoadId = Object.keys(syncedRoads.files)[0];
+
+    const testRoad = syncedRoads.file456;
+    cy.visit(`/road/${testRoad.id}`);
+    cy.url().should('include', `/road/${testRoad.id}`);
+
+    // Ensure 6.042 in test road semester 3
+    cy.getByDataCy(`road_${testRoad.id}__semester_3`)
+      .within(() => {
+        cy.getByDataCy('classInSemester3_6_042')
+          .should('exist');
+      });
+
+    cy.visit('/');
+    // Ensure 14.03 in default road
+    cy.getByDataCy(`road_${defaultRoadId}__semester_1`)
+      .within(() => {
+        cy.getByDataCy('classInSemester1_14_03')
+          .should('exist');
+      });
+
+  });
+
   it("Handles unknown road ids in url correctly (Logged Out)", () => {
     // Two things should occur, the user is redirected to the default road
     // and the url shows the id of the default road instead of the unknown road
@@ -522,7 +553,7 @@ describe('Road tests', () => {
 
 
     // Should be the road that is defaulted to when no road id is specified
-    const defaultRoadId = Object.keys(files)[0];
+    const defaultRoadId = Object.keys(syncedRoads.files)[0];
     cy.url().should('include', `/road/${defaultRoadId}`);
   });
 

--- a/tests/e2e/specs/road.js
+++ b/tests/e2e/specs/road.js
@@ -402,7 +402,7 @@ describe('Road tests', () => {
       });
   });
 
-  it("Loads correct road based on url (Logged Out)", () => {
+  it('Loads correct road based on url (Logged Out)', () => {
     cy.route(Cypress.env('VUE_APP_FIREROAD_URL') + '/courses/all?full=true',
       [
         {
@@ -485,7 +485,7 @@ describe('Road tests', () => {
             cy.getByDataCy('classInSemester1_7_46')
               .should('exist');
           });
-      })
+      });
 
     cy.visit('/');
     // Ensure 3.45 in default road
@@ -494,10 +494,9 @@ describe('Road tests', () => {
         cy.getByDataCy('classInSemester1_3_45')
           .should('exist');
       });
-
   });
 
-  it("Loads correct road based on url (Logged In)", () => {
+  it('Loads correct road based on url (Logged In)', () => {
     const fakeCode = 'abcdefg';
     const fakeAccessToken = 'jGWHEO2IfpdSEt1dyDkf';
     cy.setupAuth(fakeCode, fakeAccessToken);
@@ -527,10 +526,9 @@ describe('Road tests', () => {
         cy.getByDataCy('classInSemester1_14_03')
           .should('exist');
       });
-
   });
 
-  it("Handles unknown road ids in url correctly (Logged Out)", () => {
+  it('Handles unknown road ids in url correctly (Logged Out)', () => {
     // Two things should occur, the user is redirected to the default road
     // and the url shows the id of the default road instead of the unknown road
     cy.visit('/');
@@ -541,7 +539,7 @@ describe('Road tests', () => {
     cy.url().should('include', '/road/$defaultroad$');
   });
 
-  it("Handles unknown road ids in url correctly (Logged In)", () => {
+  it('Handles unknown road ids in url correctly (Logged In)', () => {
     // Two things should occur, the user is redirected to the default road
     // and the url shows the id of the default road instead of the unknown road
     const fakeCode = 'abcdefg';
@@ -553,10 +551,8 @@ describe('Road tests', () => {
     const randomId = 909258;
     cy.visit(`/road/${randomId}`);
 
-
     // Should be the road that is defaulted to when no road id is specified
     const defaultRoadId = Object.keys(syncedRoads.files)[0];
     cy.url().should('include', `/road/${defaultRoadId}`);
   });
-
 });

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -63,14 +63,13 @@ Cypress.Commands.add('dragAndDrop', (subject, target, dragIndex, dropIndex) => {
     .trigger('drop', { dataTransfer: dataTransfer });
 });
 
-Cypreus.Commands.add('setupAuth', (code, accessToken, opts = { addRoads: false }) => {
+Cypress.Commands.add('setupAuth', (code, accessToken) => {
   /**
       Sets up a mocked auth to test site while logged in
+      By default user has 3 roads: 123, 456, 1089
       Parameters:
       code [string] : Mocked code for user
       accessToken [string] : Fake auth token for user
-      opts:
-        addRoads [boolean] : Whether to add sync routes to some placeholder roads (123, 456, 1089)
     */
 
   // Fake authorization data
@@ -111,45 +110,43 @@ Cypreus.Commands.add('setupAuth', (code, accessToken, opts = { addRoads: false }
       success: true,
       access_info: fakeAccessInfo
     }
-  ).as('fetchToken');
+  );
 
   // Mock verify route
   cy.route(Cypress.env('VUE_APP_FIREROAD_URL') + '/verify', {
     current_semester: 4,
     success: true
-  }).as('verify');
+  });
 
   // Mock cgi people directory script
-  cy.route('/cgi-bin/people.py?kerb=tester', { year: 1 }).as('getYear');
+  cy.route('/cgi-bin/people.py?kerb=tester', { year: 1 });
 
   // Mock road syncing
   cy.route(Cypress.env('VUE_APP_FIREROAD_URL') + '/sync/roads', {
     files: syncRoadData.files,
     success: true
-  }).as('syncRoads');
+  });
 
-  if (opts.addRoads) {
-    cy.route(Cypress.env('VUE_APP_FIREROAD_URL') + '/sync/roads/?id=123', {
-      file: syncRoadData.file123,
-      success: true
-    }).as('syncRoad123');
+  cy.route(Cypress.env('VUE_APP_FIREROAD_URL') + '/sync/roads/?id=123', {
+    file: syncRoadData.file123,
+    success: true
+  });
 
-    cy.route(Cypress.env('VUE_APP_FIREROAD_URL') + '/sync/roads/?id=456', {
-      file: syncRoadData.file456,
-      success: true
-    }).as('syncRoad456');
+  cy.route(Cypress.env('VUE_APP_FIREROAD_URL') + '/sync/roads/?id=456', {
+    file: syncRoadData.file456,
+    success: true
+  });
 
-    cy.route(Cypress.env('VUE_APP_FIREROAD_URL') + '/sync/roads/?id=1089', {
-      file: syncRoadData.file1089,
-      success: true
-    }).as('syncRoad1089');
-  }
+  cy.route(Cypress.env('VUE_APP_FIREROAD_URL') + '/sync/roads/?id=1089', {
+    file: syncRoadData.file1089,
+    success: true
+  });
 });
 
 Cypress.Commands.add('login', code => {
   /**
    * Mocks login redirect and logs in
-   * Assumes you have just called cy.visit('/') and cy.setupAuth(accessToken, opts)
+   * Assumes you have just called cy.visit('/') and cy.setupAuth(accessToken)
    * Params:
    * code [string] : Mocked code for user
    */

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -63,17 +63,17 @@ Cypress.Commands.add('dragAndDrop', (subject, target, dragIndex, dropIndex) => {
     .trigger('drop', { dataTransfer: dataTransfer });
 });
 
-Cypress.Commands.add('setupAuth', (accessToken, opts = { addRoads: false }) => {
+Cypreus.Commands.add('setupAuth', (code, accessToken, opts = { addRoads: false }) => {
   /**
       Sets up a mocked auth to test site while logged in
       Parameters:
+      code [string] : Mocked code for user
       accessToken [string] : Fake auth token for user
       opts:
         addRoads [boolean] : Whether to add sync routes to some placeholder roads (123, 456, 1089)
     */
 
   // Fake authorization data
-  const fakeCode = 'abcdefg';
   const fakeAccessInfo = {
     academic_id: 'tester@mit.edu',
     access_token: accessToken,
@@ -106,7 +106,7 @@ Cypress.Commands.add('setupAuth', (accessToken, opts = { addRoads: false }) => {
 
   // Mock getting an authorization token from a code through Fireroad
   cy.route(
-    Cypress.env('VUE_APP_FIREROAD_URL') + '/fetch_token/?code=' + fakeCode,
+    Cypress.env('VUE_APP_FIREROAD_URL') + '/fetch_token/?code=' + code,
     {
       success: true,
       access_info: fakeAccessInfo
@@ -128,7 +128,7 @@ Cypress.Commands.add('setupAuth', (accessToken, opts = { addRoads: false }) => {
     success: true
   }).as('syncRoads');
 
-  if (true || opts.addRoads) {
+  if (opts.addRoads) {
     cy.route(Cypress.env('VUE_APP_FIREROAD_URL') + '/sync/roads/?id=123', {
       file: syncRoadData.file123,
       success: true
@@ -151,7 +151,7 @@ Cypress.Commands.add('login', code => {
    * Mocks login redirect and logs in
    * Assumes you have just called cy.visit('/') and cy.setupAuth(accessToken, opts)
    * Params:
-   *
+   * code [string] : Mocked code for user
    */
 
   // Prevent redirecting to Fireroad to login
@@ -162,8 +162,8 @@ Cypress.Commands.add('login', code => {
       // Expect to login via fireroad
       expect(url).to.equal(
         Cypress.env('VUE_APP_FIREROAD_URL') +
-          '/login/?redirect=' +
-          Cypress.env('VUE_APP_URL')
+        '/login/?redirect=' +
+        Cypress.env('VUE_APP_URL')
       );
       // Redirect with a fake code
       window.location.search = 'code=' + code;


### PR DESCRIPTION
Fixes #439 

It seems like the way the code is currently working, it was trying to rely on the store being initialized during the call to mounted, but that's actually not the case, it's just an empty object during mounted. 

As such, it couldn't find the road in the url and so it set the url to whatever the active road is, which is the default road. On a second call to setting the active road, it would see that the url shows the default road and that's why this issue occurred.

My current solution feels a little hacky so if you know of a way to ensure that the store is loaded when you call mounted, that'd probably be a better way to solve this issue.